### PR TITLE
Discovery announce listen address

### DIFF
--- a/discovery/src/lib.rs
+++ b/discovery/src/lib.rs
@@ -19,7 +19,7 @@ pub use crate::{
     substream::{Direction, Substream, SubstreamKey, SubstreamValue},
 };
 
-use crate::addr::DEFAULT_MAX_KNOWN;
+use crate::{addr::DEFAULT_MAX_KNOWN, substream::RemoteAddress};
 
 pub struct Discovery<M> {
     // Default: 5000
@@ -82,6 +82,7 @@ impl<M: AddressManager> Discovery<M> {
                         substream.stream,
                         self.max_known,
                         substream.remote_addr,
+                        substream.listen_port,
                     );
                     self.substreams.insert(key, value);
                 }
@@ -141,7 +142,9 @@ impl<M: AddressManager> Stream for Discovery<M> {
             }
 
             if value.announce {
-                announce_addrs.push(RawAddr::from(value.remote_addr));
+                if let RemoteAddress::Listen(addr) = value.remote_addr {
+                    announce_addrs.push(RawAddr::from(addr));
+                }
                 value.announce = false;
             }
         }

--- a/discovery/src/message.rs
+++ b/discovery/src/message.rs
@@ -60,7 +60,11 @@ impl Encoder for DiscoveryCodec {
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
 pub enum DiscoveryMessage {
-    GetNodes { version: u32, count: u32 },
+    GetNodes {
+        version: u32,
+        count: u32,
+        listen_port: Option<u16>,
+    },
     Nodes(Nodes),
 }
 
@@ -78,7 +82,7 @@ pub struct Node {
 impl std::fmt::Display for DiscoveryMessage {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         match self {
-            DiscoveryMessage::GetNodes { version, count } => {
+            DiscoveryMessage::GetNodes { version, count, .. } => {
                 write!(
                     f,
                     "DiscoveryMessage::GetNodes(version:{}, count:{})",

--- a/discovery/src/substream.rs
+++ b/discovery/src/substream.rs
@@ -111,7 +111,7 @@ pub struct SubstreamValue {
     pub(crate) pending_messages: VecDeque<DiscoveryMessage>,
     pub(crate) addr_known: AddrKnown,
     // FIXME: Remote listen address, resolved by id protocol
-    pub(crate) remote_addr: SocketAddr,
+    pub(crate) remote_addr: RemoteAddress,
     pub(crate) announce: bool,
     pub(crate) announce_addrs: Vec<RawAddr>,
     timer_future: Interval,
@@ -126,17 +126,23 @@ impl SubstreamValue {
         stream: StreamHandle,
         max_known: usize,
         remote_addr: SocketAddr,
+        listen_port: Option<u16>,
     ) -> SubstreamValue {
         let mut pending_messages = VecDeque::default();
         debug!("direction: {:?}", direction);
-        if direction == Direction::Outbound {
+        let mut addr_known = AddrKnown::new(max_known);
+        let remote_addr = if direction == Direction::Outbound {
             pending_messages.push_back(DiscoveryMessage::GetNodes {
                 version: VERSION,
                 count: MAX_ADDR_TO_SEND as u32,
+                listen_port,
             });
-        }
-        let mut addr_known = AddrKnown::new(max_known);
-        addr_known.insert(RawAddr::from(remote_addr));
+            addr_known.insert(RawAddr::from(remote_addr));
+
+            RemoteAddress::Listen(remote_addr)
+        } else {
+            RemoteAddress::Init(remote_addr)
+        };
 
         SubstreamValue {
             framed_stream: Framed::new(stream, DiscoveryCodec::default()),
@@ -189,15 +195,23 @@ impl SubstreamValue {
         addr_mgr: &mut M,
     ) -> Result<Option<Nodes>, io::Error> {
         match message {
-            DiscoveryMessage::GetNodes { .. } => {
+            DiscoveryMessage::GetNodes { listen_port, .. } => {
                 if self.received_get_nodes {
                     // TODO: misbehavior
-                    if addr_mgr.misbehave(self.remote_addr, 111) < 0 {
+                    if addr_mgr.misbehave(self.remote_addr.into_inner(), 111) < 0 {
                         // TODO: more clear error type
                         warn!("Already received get nodes");
                         return Err(io::ErrorKind::Other.into());
                     }
                 } else {
+                    /// change client random outbound port to client listen port
+                    debug!("listen port: {:?}", listen_port);
+                    if let Some(port) = listen_port {
+                        self.remote_addr.as_mut().set_port(port);
+                        self.addr_known.insert(self.remote_addr.into_inner().into());
+                        self.remote_addr = self.remote_addr.into_listen();
+                    }
+
                     // TODO: magic number
                     let mut items = addr_mgr.get_random(2500);
                     while items.len() > 1000 {
@@ -226,7 +240,7 @@ impl SubstreamValue {
                     if nodes.items.len() > ANNOUNCE_THRESHOLD {
                         warn!("Nodes number more than {}", ANNOUNCE_THRESHOLD);
                         // TODO: misbehavior
-                        if addr_mgr.misbehave(self.remote_addr, 222) < 0 {
+                        if addr_mgr.misbehave(self.remote_addr.into_inner(), 222) < 0 {
                             // TODO: more clear error type
                             return Err(io::ErrorKind::Other.into());
                         }
@@ -236,7 +250,7 @@ impl SubstreamValue {
                 } else if self.received_nodes {
                     warn!("already received Nodes(announce=false) message");
                     // TODO: misbehavior
-                    if addr_mgr.misbehave(self.remote_addr, 333) < 0 {
+                    if addr_mgr.misbehave(self.remote_addr.into_inner(), 333) < 0 {
                         // TODO: more clear error type
                         return Err(io::ErrorKind::Other.into());
                     }
@@ -246,7 +260,7 @@ impl SubstreamValue {
                         nodes.items.len()
                     );
                     // TODO: misbehavior
-                    if addr_mgr.misbehave(self.remote_addr, 444) < 0 {
+                    if addr_mgr.misbehave(self.remote_addr.into_inner(), 444) < 0 {
                         // TODO: more clear error type
                         return Err(io::ErrorKind::Other.into());
                     }
@@ -276,6 +290,7 @@ impl SubstreamValue {
                         // Add to known address list
                         for node in &nodes.items {
                             for addr in &node.addresses {
+                                trace!("received address: {}", addr.socket_addr());
                                 self.addr_known.insert(*addr);
                             }
                         }
@@ -300,6 +315,7 @@ pub struct Substream {
     pub remote_addr: SocketAddr,
     pub direction: Direction,
     pub stream: StreamHandle,
+    pub listen_port: Option<u16>,
 }
 
 impl Substream {
@@ -310,6 +326,7 @@ impl Substream {
         session_id: SessionId,
         receiver: Receiver<Vec<u8>>,
         sender: Sender<ServiceTask>,
+        listens: &[SocketAddr],
     ) -> Substream {
         let stream = StreamHandle {
             data_buf: BytesMut::default(),
@@ -318,10 +335,27 @@ impl Substream {
             receiver,
             sender,
         };
+        let listen_port = if direction == Direction::Outbound {
+            let local = remote_addr.ip().is_loopback();
+
+            listens
+                .iter()
+                .filter_map(|address| {
+                    if local || RawAddr::from(*address).is_reachable() {
+                        Some(address.port())
+                    } else {
+                        None
+                    }
+                })
+                .nth(0)
+        } else {
+            None
+        };
         Substream {
             remote_addr,
             direction,
             stream,
+            listen_port,
         }
     }
 }
@@ -342,4 +376,32 @@ pub enum Direction {
     Inbound,
     // The connection(session) is open by current peer
     Outbound,
+}
+
+#[derive(Eq, PartialEq, Hash, Debug, Clone, Copy)]
+pub(crate) enum RemoteAddress {
+    /// Inbound init remote address
+    Init(SocketAddr),
+    /// Outbound init remote address or Inbound listen address
+    Listen(SocketAddr),
+}
+
+impl RemoteAddress {
+    pub(crate) fn into_inner(self) -> SocketAddr {
+        match self {
+            RemoteAddress::Init(addr) | RemoteAddress::Listen(addr) => addr,
+        }
+    }
+
+    pub(crate) fn as_mut(&mut self) -> &mut SocketAddr {
+        match self {
+            RemoteAddress::Init(ref mut addr) | RemoteAddress::Listen(ref mut addr) => addr,
+        }
+    }
+
+    fn into_listen(self) -> Self {
+        match self {
+            RemoteAddress::Init(addr) | RemoteAddress::Listen(addr) => RemoteAddress::Listen(addr),
+        }
+    }
 }

--- a/examples/disc.rs
+++ b/examples/disc.rs
@@ -47,7 +47,7 @@ fn main() {
             .forever(true)
             .build(SHandle {})
             .dial("127.0.0.1:1337".parse().unwrap());
-        let _ = service.listen("127.0.0.1:1337".parse().unwrap());
+        let _ = service.listen("127.0.0.1:1338".parse().unwrap());
         tokio::run(service.for_each(|_| Ok(())))
     }
 }
@@ -194,6 +194,7 @@ impl ProtocolHandle for DiscoveryProtocol {
             session_id,
             receiver,
             control.sender().clone(),
+            control.listens(),
         );
         match self.discovery_handle.substream_sender.try_send(substream) {
             Ok(_) => {

--- a/src/service.rs
+++ b/src/service.rs
@@ -749,8 +749,16 @@ where
         match event {
             ServiceTask::ProtocolMessage { ids, message } => self.filter_broadcast(ids, message),
             ServiceTask::Dial { address } => {
-                let dial = TcpStream::connect(&address);
-                self.dial.push((address, dial));
+                if self
+                    .dial
+                    .iter()
+                    .map(|(address, _)| address)
+                    .find(|addr| addr == &&address)
+                    .is_none()
+                {
+                    let dial = TcpStream::connect(&address);
+                    self.dial.push((address, dial));
+                }
             }
             ServiceTask::Disconnect { id } => self.session_close(id),
             ServiceTask::FutureTask { task } => {

--- a/src/session.rs
+++ b/src/session.rs
@@ -3,9 +3,9 @@ use log::{debug, error, trace, warn};
 use secio::{codec::stream_handle::StreamHandle as SecureHandle, PublicKey};
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::{error, io, net::SocketAddr};
+use std::{error, io, net::SocketAddr, time::Duration};
 use tokio::codec::{Decoder, Encoder, Framed};
-use tokio::prelude::{AsyncRead, AsyncWrite};
+use tokio::prelude::{AsyncRead, AsyncWrite, FutureExt};
 use yamux::{session::SessionType, Config, Session as YamuxSession, StreamHandle};
 
 use crate::protocol_select::{client_select, server_select, ProtocolInfo};
@@ -224,6 +224,7 @@ where
                 }
                 Ok(())
             })
+            .timeout(Duration::from_secs(10))
             .map_err(|err| {
                 trace!("stream protocol select err: {:?}", err);
             });
@@ -276,6 +277,7 @@ where
                 }
                 Ok(())
             })
+            .timeout(Duration::from_secs(10))
             .map_err(|err| {
                 trace!("stream protocol select err: {:?}", err);
             });


### PR DESCRIPTION
The previous announce is the broadcast client's random address. Now it needs to confirm it as the listening address first, otherwise, it will not broadcast.