### PR TITLE
Replace socket address with multiaddr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ log = "0.4"
 bytes = "0.4"
 
 flatbuffers = "0.5.0"
+multiaddr = { package = "parity-multiaddr", version = "0.1.0" }
 
 [dev-dependencies]
 env_logger = "0.6.0"

--- a/discovery/src/addr.rs
+++ b/discovery/src/addr.rs
@@ -1,3 +1,4 @@
+use p2p::multiaddr::Multiaddr;
 use std::collections::BTreeMap;
 use std::net::{IpAddr, SocketAddr};
 use std::time::Instant;
@@ -15,9 +16,9 @@ pub(crate) const DEFAULT_MAX_KNOWN: usize = 5000;
 
 // FIXME: Should be peer store?
 pub trait AddressManager {
-    fn add_new(&mut self, addr: SocketAddr);
-    fn misbehave(&mut self, addr: SocketAddr, ty: u64) -> i32;
-    fn get_random(&mut self, n: usize) -> Vec<SocketAddr>;
+    fn add_new(&mut self, addr: Multiaddr);
+    fn misbehave(&mut self, addr: Multiaddr, ty: u64) -> i32;
+    fn get_random(&mut self, n: usize) -> Vec<Multiaddr>;
 }
 
 // bitcoin: bloom.h, bloom.cpp => CRollingBloomFilter

--- a/discovery/src/lib.rs
+++ b/discovery/src/lib.rs
@@ -7,6 +7,7 @@ use futures::{
     Async, Poll, Stream,
 };
 use log::debug;
+use p2p::multiaddr::ToMultiaddr;
 use rand::seq::SliceRandom;
 
 mod addr;
@@ -203,7 +204,8 @@ impl<M: AddressManager> Stream for Discovery<M> {
             Some((_key, nodes)) => {
                 for node in nodes.items.into_iter() {
                     for addr in node.addresses.into_iter() {
-                        self.addr_mgr.add_new(addr.socket_addr());
+                        self.addr_mgr
+                            .add_new(addr.socket_addr().to_multiaddr().unwrap());
                     }
                 }
                 Ok(Async::Ready(Some(())))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,3 +18,5 @@ pub use secio::{PublicKey, SecioKeyPair};
 pub use yamux::{session::SessionType, Session};
 /// Protocol select
 pub mod protocol_select;
+/// Re-pub multiaddr crate
+pub use multiaddr;

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,9 +1,10 @@
 use futures::{prelude::*, sync::mpsc};
 use log::{debug, error, trace, warn};
+use multiaddr::Multiaddr;
 use secio::{codec::stream_handle::StreamHandle as SecureHandle, PublicKey};
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::{error, io, net::SocketAddr, time::Duration};
+use std::{error, io, time::Duration};
 use tokio::codec::{Decoder, Encoder, Framed};
 use tokio::prelude::{AsyncRead, AsyncWrite, FutureExt};
 use yamux::{session::SessionType, Config, Session as YamuxSession, StreamHandle};
@@ -33,7 +34,7 @@ pub(crate) enum SessionEvent {
         /// Remote Public key
         public_key: PublicKey,
         /// Remote address
-        address: SocketAddr,
+        address: Multiaddr,
         /// Session type
         ty: SessionType,
     },


### PR DESCRIPTION
In order to support multiple protocols, it is necessary to replace the socket address with `multiaddr`.

The core implementation of `multiaddr` is to parse the string into the specified format of the bytes storage, we do not need to re-implement this library again

The two existing crate implementations can be said to be very similar, and `cid` has a known unresolved bug, so the version of libp2p implementation is chosen.

Discovery may need to rethink the implementation of the store, because the Rawaddr structure should be deleted.

Currently, we only support TCP/IP, multi-protocol support, consider again after stabilization.