### PR TITLE
bump to 0.2.0-alpha.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tentacle"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 license = "MIT"
 description = "Minimal implementation for a multiplexed p2p network framework."
 authors = ["piaoliu <441594700@qq.com>", "Nervos Core Dev <dev@nervos.org>"]
@@ -29,10 +29,12 @@ env_logger = "0.6.0"
 fnv = "1.0"
 discovery = { path = "discovery", package="tentacle-discovery" }
 crossbeam-channel = "0.3.6"
-systemstat = "0.1.3"
-nix = "0.13.0"
 ping = { path = "ping", package = "tentacle-ping" }
 generic-channel = { version = "0.2.0", features = ["all"] }
+systemstat = "0.1.3"
+
+[target.'cfg(unix)'.dev-dependencies]
+nix = "0.13.0"
 
 [workspace]
 members = ["yamux", "secio", "discovery", "ping", "bench"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # P2P
 
 [![Build Status](https://api.travis-ci.org/driftluo/p2p.svg?branch=master)](https://travis-ci.org/driftluo/p2p)
-![image](https://img.shields.io/badge/rustc-1.31.1-blue.svg)
+![image](https://img.shields.io/badge/rustc-1.33-blue.svg)
 
 ## Overview
 
@@ -38,7 +38,7 @@ The API of this project is basically usable. However we still need more tests. P
 
 ```toml
 [dependencies]
-tentacle = "0.1"
+tentacle = "0.2"
 ```
 
 ### Example

--- a/src/utils/dns.rs
+++ b/src/utils/dns.rs
@@ -96,7 +96,10 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::{multiaddr::Multiaddr, utils::dns::DNSResolver};
+    use crate::{
+        multiaddr::{Multiaddr, Protocol},
+        utils::dns::DNSResolver,
+    };
 
     #[test]
     fn dns_parser() {
@@ -104,6 +107,12 @@ mod test {
             DNSResolver::new("/dns4/localhost/tcp/80".parse().unwrap()).unwrap();
         let mut rt = tokio::runtime::Runtime::new().unwrap();
         let addr = rt.block_on(future).unwrap();
-        assert_eq!("/ip4/127.0.0.1/tcp/80".parse::<Multiaddr>().unwrap(), addr)
+        match addr.iter().next().unwrap() {
+            Protocol::Ip4(_) => {
+                assert_eq!("/ip4/127.0.0.1/tcp/80".parse::<Multiaddr>().unwrap(), addr)
+            }
+            Protocol::Ip6(_) => assert_eq!("/ip6/::1/tcp/80".parse::<Multiaddr>().unwrap(), addr),
+            _ => panic!("Dns resolver fail"),
+        }
     }
 }


### PR DESCRIPTION
We have modified a lot of APIs for friendliness and functionality, and it’s time to release the 0.2 alpha version.

Some adjustments may be made later, depending on the situation