### PR TITLE
Stop ws support plan

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -50,12 +50,19 @@ pub fn extract_peer_id(addr: &Multiaddr) -> Option<PeerId> {
     })
 }
 
+/// Determine if it is a WebSocket protocol
+pub fn is_ws(addr: &Multiaddr) -> bool {
+    let mut iter = addr.iter();
+
+    iter.any(|proto| proto == Protocol::Ws || proto == Protocol::Wss)
+}
+
 #[cfg(test)]
 mod test {
     use crate::{
         multiaddr::Multiaddr,
         secio::SecioKeyPair,
-        utils::{extract_peer_id, multiaddr_to_socketaddr},
+        utils::{extract_peer_id, is_ws, multiaddr_to_socketaddr},
     };
 
     #[test]
@@ -99,5 +106,15 @@ mod test {
             .parse()
             .unwrap();
         multiaddr_to_socketaddr(&addr).unwrap();
+    }
+
+    #[test]
+    fn test_ws_judgment() {
+        let addr_1 = "/ip4/127.0.0.1/tcp/1337/ws".parse().unwrap();
+        let addr_2 = "/ip4/127.0.0.1/tcp/1337/wss".parse().unwrap();
+        let addr_3 = "/ip4/127.0.0.1/tcp/1337".parse().unwrap();
+        assert_eq!(is_ws(&addr_1), true);
+        assert_eq!(is_ws(&addr_2), true);
+        assert_eq!(is_ws(&addr_3), false);
     }
 }


### PR DESCRIPTION
Originally, this pr will add websocket protocol support, but I gave up on this plan.

Why stop:

1. Currently, our demand for WebSocket is not strong
2. [ws](https://crates.io/crates/ws) is based on [mio](https://crates.io/crates/mio) development, system independence, if we want to integrate, it means that we need `mio` and `tokio` (bottom `mio`) two sets of runtime to run at the same time, this program does not look good
3. [websocket](https://crates.io/crates/websocket) is indeed a library in the `tokio` ecosystem, which is relatively easy to integrate. However, it also has problems, httparse has not started working, relying on hyper 0.10. [ref1](https://github.com/websockets-rs/rust-websocket/issues/132)/[ref2](https://github.com/websockets-rs/rust-websocket/issues/192)

For the above reasons, I decided to suspend support for the underlying websocket protocol.