### PR TITLE
Use generic

### DIFF
--- a/src/protocol_handle_stream.rs
+++ b/src/protocol_handle_stream.rs
@@ -34,17 +34,20 @@ pub enum ServiceProtocolEvent {
     },
 }
 
-pub struct ServiceProtocolStream {
-    handle: Box<dyn ServiceProtocol + Send + 'static>,
+pub struct ServiceProtocolStream<T> {
+    handle: T,
     /// External event is passed in from this
     handle_context: ProtocolContext,
     sessions: HashMap<SessionId, SessionContext>,
     receiver: mpsc::Receiver<ServiceProtocolEvent>,
 }
 
-impl ServiceProtocolStream {
+impl<T> ServiceProtocolStream<T>
+where
+    T: ServiceProtocol + Send,
+{
     pub fn new(
-        handle: Box<dyn ServiceProtocol + Send + 'static>,
+        handle: T,
         service_context: ServiceContext,
         receiver: mpsc::Receiver<ServiceProtocolEvent>,
         proto_id: ProtocolId,
@@ -89,7 +92,10 @@ impl ServiceProtocolStream {
     }
 }
 
-impl Stream for ServiceProtocolStream {
+impl<T> Stream for ServiceProtocolStream<T>
+where
+    T: ServiceProtocol + Send,
+{
     type Item = ();
     type Error = ();
 
@@ -144,17 +150,20 @@ pub enum SessionProtocolEvent {
     },
 }
 
-pub struct SessionProtocolStream {
-    handle: Box<dyn SessionProtocol + Send + 'static>,
+pub struct SessionProtocolStream<T> {
+    handle: T,
     /// External event is passed in from this
     handle_context: ProtocolContext,
     context: SessionContext,
     receiver: mpsc::Receiver<SessionProtocolEvent>,
 }
 
-impl SessionProtocolStream {
+impl<T> SessionProtocolStream<T>
+where
+    T: SessionProtocol + Send,
+{
     pub fn new(
-        handle: Box<dyn SessionProtocol + Send + 'static>,
+        handle: T,
         service_context: ServiceContext,
         context: SessionContext,
         receiver: mpsc::Receiver<SessionProtocolEvent>,
@@ -201,7 +210,10 @@ impl SessionProtocolStream {
     }
 }
 
-impl Stream for SessionProtocolStream {
+impl<T> Stream for SessionProtocolStream<T>
+where
+    T: SessionProtocol + Send,
+{
     type Item = ();
     type Error = ();
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -149,3 +149,103 @@ impl ServiceHandle for Box<dyn ServiceHandle + Send + Sync + 'static> {
 }
 
 impl ServiceHandle for () {}
+
+impl ServiceProtocol for Box<dyn ServiceProtocol + Send + 'static> {
+    fn init(&mut self, context: &mut ProtocolContext) {
+        (&mut **self).init(context)
+    }
+
+    fn connected(&mut self, context: ProtocolContextMutRef, version: &str) {
+        (&mut **self).connected(context, version)
+    }
+
+    fn disconnected(&mut self, context: ProtocolContextMutRef) {
+        (&mut **self).disconnected(context)
+    }
+
+    fn received(&mut self, context: ProtocolContextMutRef, data: bytes::Bytes) {
+        (&mut **self).received(context, data)
+    }
+
+    fn notify(&mut self, context: &mut ProtocolContext, token: u64) {
+        (&mut **self).notify(context, token)
+    }
+
+    #[inline]
+    fn poll(&mut self, context: &mut ProtocolContext) {
+        (&mut **self).poll(context)
+    }
+}
+
+impl ServiceProtocol for Box<dyn ServiceProtocol + Send + Sync + 'static> {
+    fn init(&mut self, context: &mut ProtocolContext) {
+        (&mut **self).init(context)
+    }
+
+    fn connected(&mut self, context: ProtocolContextMutRef, version: &str) {
+        (&mut **self).connected(context, version)
+    }
+
+    fn disconnected(&mut self, context: ProtocolContextMutRef) {
+        (&mut **self).disconnected(context)
+    }
+
+    fn received(&mut self, context: ProtocolContextMutRef, data: bytes::Bytes) {
+        (&mut **self).received(context, data)
+    }
+
+    fn notify(&mut self, context: &mut ProtocolContext, token: u64) {
+        (&mut **self).notify(context, token)
+    }
+
+    #[inline]
+    fn poll(&mut self, context: &mut ProtocolContext) {
+        (&mut **self).poll(context)
+    }
+}
+
+impl SessionProtocol for Box<dyn SessionProtocol + Send + 'static> {
+    fn connected(&mut self, context: ProtocolContextMutRef, version: &str) {
+        (&mut **self).connected(context, version)
+    }
+
+    fn disconnected(&mut self, context: ProtocolContextMutRef) {
+        (&mut **self).disconnected(context)
+    }
+
+    fn received(&mut self, context: ProtocolContextMutRef, data: bytes::Bytes) {
+        (&mut **self).received(context, data)
+    }
+
+    fn notify(&mut self, context: ProtocolContextMutRef, token: u64) {
+        (&mut **self).notify(context, token)
+    }
+
+    #[inline]
+    fn poll(&mut self, context: ProtocolContextMutRef) {
+        (&mut **self).poll(context)
+    }
+}
+
+impl SessionProtocol for Box<dyn SessionProtocol + Send + Sync + 'static> {
+    fn connected(&mut self, context: ProtocolContextMutRef, version: &str) {
+        (&mut **self).connected(context, version)
+    }
+
+    fn disconnected(&mut self, context: ProtocolContextMutRef) {
+        (&mut **self).disconnected(context)
+    }
+
+    fn received(&mut self, context: ProtocolContextMutRef, data: bytes::Bytes) {
+        (&mut **self).received(context, data)
+    }
+
+    fn notify(&mut self, context: ProtocolContextMutRef, token: u64) {
+        (&mut **self).notify(context, token)
+    }
+
+    #[inline]
+    fn poll(&mut self, context: ProtocolContextMutRef) {
+        (&mut **self).poll(context)
+    }
+}


### PR DESCRIPTION
The reason we use trait object now is that the `impl trait` implementation is incomplete and cannot be used in scenarios other than function. 

When anonymous generics can be widely used in Fn / Trait Fn, generics can be used directly, so we can use generics to define structures in advance.