### PR TITLE
chore: release 0.2-alpha.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tentacle"
-version = "0.2.0-alpha.1"
+version = "0.2.0-alpha.2"
 license = "MIT"
 description = "Minimal implementation for a multiplexed p2p network framework."
 authors = ["piaoliu <441594700@qq.com>", "Nervos Core Dev <dev@nervos.org>"]
@@ -12,8 +12,8 @@ categories = ["network-programming", "asynchronous"]
 edition = "2018"
 
 [dependencies]
-yamux = { path = "yamux", version = "0.1.4", package = "tokio-yamux" }
-secio = { path = "secio", version = "0.1.0", package = "tentacle-secio" }
+yamux = { path = "yamux", version = "0.1.5", package = "tokio-yamux" }
+secio = { path = "secio", version = "0.1.1", package = "tentacle-secio" }
 
 futures = "0.1"
 tokio = "0.1"

--- a/protocols/discovery/Cargo.toml
+++ b/protocols/discovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tentacle-discovery"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Linfeng Qian <thewawar@gmail.com>"]
 license = "MIT"
 description = "p2p discovery protocol main reference bitcoin"
@@ -10,7 +10,7 @@ categories = ["network-programming", "asynchronous"]
 edition = "2018"
 
 [dependencies]
-p2p = { path = "../..", version = "0.2.0-alpha.1", package = "tentacle" }
+p2p = { path = "../..", version = "0.2.0-alpha.2", package = "tentacle" }
 bytes = "0.4"
 byteorder = "1.2"
 fnv = "1.0"

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tentacle-identify"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Qian Linfeng <thewawar@gmail.com>"]
 license = "MIT"
 description = "p2p identify protocol"
@@ -10,7 +10,7 @@ categories = ["network-programming", "asynchronous"]
 edition = "2018"
 
 [dependencies]
-p2p = { path = "../..", version = "0.2.0-alpha.1", package = "tentacle" }
+p2p = { path = "../..", version = "0.2.0-alpha.2", package = "tentacle" }
 bytes = "0.4"
 flatbuffers = "0.5.0"
 flatbuffers-verifier = "0.1.8"

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tentacle-ping"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 license = "MIT"
 keywords = ["network", "peer-to-peer", "p2p", "ping"]
@@ -10,7 +10,7 @@ description = "ping protocol implementation for tentacle"
 edition = "2018"
 
 [dependencies]
-p2p = { path = "../..", version = "0.2.0-alpha.1", package = "tentacle" }
+p2p = { path = "../..", version = "0.2.0-alpha.2", package = "tentacle" }
 log = "0.4"
 flatbuffers = "0.5.0"
 flatbuffers-verifier = "0.1.8"

--- a/secio/Cargo.toml
+++ b/secio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tentacle-secio"
-version = "0.1.0"
+version = "0.1.1"
 license = "MIT"
 description = "Secio encryption protocol for p2p"
 authors = ["piaoliu <441594700@qq.com>", "Nervos Core Dev <dev@nervos.org>"]

--- a/yamux/Cargo.toml
+++ b/yamux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-yamux"
-version = "0.1.4"
+version = "0.1.5"
 license = "MIT"
 repository = "https://github.com/nervosnetwork/p2p"
 description = "Rust implementation of Yamux"


### PR DESCRIPTION
It’s been a long time since the last release, and we have a lot of changes and fixes. It’s time to release a new version.

This version is now infinitely close to the official release of 0.2.0, I hope there will be no big changes in the future.