### PR TITLE
chore: upgrade multi-address

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ tokio-threadpool = "0.1"
 
 flatbuffers = "0.5.0"
 flatbuffers-verifier = "0.1.8"
-multiaddr = { package = "parity-multiaddr", version = "0.3.0" }
+multiaddr = { package = "parity-multiaddr", version = "0.4.0" }
 
 [dev-dependencies]
 env_logger = "0.6.0"

--- a/protocols/discovery/src/protocol.rs
+++ b/protocols/discovery/src/protocol.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::{convert::TryFrom, io};
 
 use bytes::{Bytes, BytesMut};
 use flatbuffers::FlatBufferBuilder;
@@ -96,7 +96,7 @@ impl DiscoveryMessage {
                 for item in items {
                     let mut vec_addrs = Vec::new();
                     for address in &item.addresses {
-                        let seq = fbb.create_vector(&address.to_bytes());
+                        let seq = fbb.create_vector(address.as_ref());
                         let mut bytes_builder = BytesBuilder::new(&mut fbb);
                         bytes_builder.add_seq(seq);
                         vec_addrs.push(bytes_builder.finish());
@@ -149,7 +149,7 @@ impl DiscoveryMessage {
                     let mut addresses = Vec::new();
                     for j in 0..fbs_addresses.len() {
                         let address = fbs_addresses.get(j);
-                        let multiaddr = Multiaddr::from_bytes(address.seq()?.to_vec()).ok()?;
+                        let multiaddr = Multiaddr::try_from(address.seq()?.to_vec()).ok()?;
                         addresses.push(multiaddr);
                     }
                     items.push(Node { addresses });

--- a/protocols/identify/src/protocol.rs
+++ b/protocols/identify/src/protocol.rs
@@ -9,6 +9,8 @@ use crate::protocol_generated::p2p::identify::{
 use bytes::Bytes;
 use p2p::multiaddr::Multiaddr;
 
+use std::convert::TryFrom;
+
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum IdentifyMessage {
     ListenAddrs(Vec<Multiaddr>),
@@ -79,12 +81,12 @@ fn addr_to_offset<'b>(
     fbb: &mut FlatBufferBuilder<'b>,
     addr: &Multiaddr,
 ) -> WIPOffset<FbsAddress<'b>> {
-    let bytes = fbb.create_vector(&addr.to_bytes());
+    let bytes = fbb.create_vector(addr.as_ref());
     let mut addr_builder = AddressBuilder::new(fbb);
     addr_builder.add_bytes(bytes);
     addr_builder.finish()
 }
 
 fn fbs_to_addr(addr: &FbsAddress) -> Option<Multiaddr> {
-    Multiaddr::from_bytes(addr.bytes()?.to_vec()).ok()
+    Multiaddr::try_from(addr.bytes()?.to_vec()).ok()
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -728,7 +728,7 @@ where
                             return;
                         }
                     } else {
-                        address.append(Protocol::P2p(
+                        address.push(Protocol::P2p(
                             Multihash::from_bytes(key.peer_id().into_bytes())
                                 .expect("Invalid peer id"),
                         ))

--- a/src/transports/mod.rs
+++ b/src/transports/mod.rs
@@ -1,4 +1,4 @@
-use crate::multiaddr::{Multiaddr, ToMultiaddr};
+use crate::{multiaddr::Multiaddr, utils::socketaddr_to_multiaddr};
 
 use futures::prelude::{Async, Future, Poll, Stream};
 use log::debug;
@@ -180,9 +180,7 @@ impl Stream for MultiIncoming {
                 // so why incoming will appear unconnected stream ?
                 Async::Ready(Some(stream)) => match stream.peer_addr() {
                     Ok(remote_address) => Ok(Async::Ready(Some((
-                        remote_address
-                            .to_multiaddr()
-                            .expect("socket address to multiaddr fail"),
+                        socketaddr_to_multiaddr(remote_address),
                         MultiStream::Tcp(stream),
                     )))),
                     Err(err) => {

--- a/src/transports/tcp.rs
+++ b/src/transports/tcp.rs
@@ -11,9 +11,9 @@ use tokio::{
 };
 
 use crate::{
-    multiaddr::{Multiaddr, ToMultiaddr},
+    multiaddr::Multiaddr,
     transports::{Transport, TransportError},
-    utils::{dns::DNSResolver, multiaddr_to_socketaddr},
+    utils::{dns::DNSResolver, multiaddr_to_socketaddr, socketaddr_to_multiaddr},
 };
 
 /// Tcp listen bind
@@ -21,11 +21,8 @@ fn bind(address: Multiaddr) -> Result<(Multiaddr, Incoming), TransportError> {
     match multiaddr_to_socketaddr(&address) {
         Some(socket_address) => {
             let tcp = TcpListener::bind(&socket_address).map_err(TransportError::Io)?;
-            let listen_addr = tcp
-                .local_addr()
-                .map_err(TransportError::Io)?
-                .to_multiaddr()
-                .unwrap();
+            let listen_addr =
+                socketaddr_to_multiaddr(tcp.local_addr().map_err(TransportError::Io)?);
 
             Ok((listen_addr, tcp.incoming()))
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,10 @@ use crate::{
     multiaddr::{Multiaddr, Protocol},
     secio::PeerId,
 };
-use std::net::{IpAddr, SocketAddr};
+use std::{
+    iter::{self, FromIterator},
+    net::{IpAddr, SocketAddr},
+};
 
 /// This module create a `DNSResolver` future task to DNS resolver
 pub mod dns;
@@ -83,6 +86,16 @@ pub fn multiaddr_to_socketaddr(addr: &Multiaddr) -> Option<SocketAddr> {
     }
 
     None
+}
+
+/// convert socket address to multiaddr
+pub fn socketaddr_to_multiaddr(address: SocketAddr) -> Multiaddr {
+    let proto = match address.ip() {
+        IpAddr::V4(ip) => Protocol::Ip4(ip),
+        IpAddr::V6(ip) => Protocol::Ip6(ip),
+    };
+    let it = iter::once(proto).chain(iter::once(Protocol::Tcp(address.port())));
+    Multiaddr::from_iter(it)
 }
 
 /// Get peer id from multiaddr

--- a/tests/test_peer_id.rs
+++ b/tests/test_peer_id.rs
@@ -100,7 +100,7 @@ fn test_peer_id(fail: bool) {
     if fail {
         (1..11).for_each(|_| {
             let mut addr = listen_addr.clone();
-            addr.append(MultiProtocol::P2p(
+            addr.push(MultiProtocol::P2p(
                 Multihash::from_bytes(
                     SecioKeyPair::secp256k1_generated()
                         .to_peer_id()
@@ -113,7 +113,7 @@ fn test_peer_id(fail: bool) {
         });
         assert_eq!(error_receiver.recv(), Ok(9));
     } else {
-        listen_addr.append(MultiProtocol::P2p(
+        listen_addr.push(MultiProtocol::P2p(
             Multihash::from_bytes(key.to_peer_id().into_bytes()).expect("Invalid peer id"),
         ));
         control.dial(listen_addr, DialProtocol::All).unwrap();


### PR DESCRIPTION
1. Upgrade `multi-address`
2. `multi-address` has break change, we may publish a new version for all protocol and `tentacle`(wait for 0.2.0 ?)