### PR TITLE
feat: add before handle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tentacle"
-version = "0.2.0-alpha.18"
+version = "0.2.0"
 license = "MIT"
 description = "Minimal implementation for a multiplexed p2p network framework."
 authors = ["piaoliu <441594700@qq.com>", "Nervos Core Dev <dev@nervos.org>"]

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ $ RUST_LOG=simple=info,tentacle=debug cargo run --example simple
 
 4. Now you can see some data interaction information on the terminal.
 
+You can see more detailed example in these two repos: [ckb](https://github.com/nervosnetwork/ckb)/[cita](https://github.com/cryptape/cita).
+
 ## Why?
 
 Because when I use `rust-libp2p`, I have encountered some difficult problems,

--- a/protocols/discovery/Cargo.toml
+++ b/protocols/discovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tentacle-discovery"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Linfeng Qian <thewawar@gmail.com>"]
 license = "MIT"
 description = "p2p discovery protocol main reference bitcoin"
@@ -10,7 +10,7 @@ categories = ["network-programming", "asynchronous"]
 edition = "2018"
 
 [dependencies]
-p2p = { path = "../..", version = "0.2.0-alpha.13", package = "tentacle" }
+p2p = { path = "../..", version = "0.2.0", package = "tentacle" }
 bytes = "0.4"
 byteorder = "1.2"
 fnv = "1.0"

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tentacle-identify"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Qian Linfeng <thewawar@gmail.com>"]
 license = "MIT"
 description = "p2p identify protocol"
@@ -10,7 +10,7 @@ categories = ["network-programming", "asynchronous"]
 edition = "2018"
 
 [dependencies]
-p2p = { path = "../..", version = "0.2.0-alpha.13", package = "tentacle" }
+p2p = { path = "../..", version = "0.2.0", package = "tentacle" }
 bytes = "0.4"
 flatbuffers = "0.6.0"
 flatbuffers-verifier = "0.2.0"

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tentacle-ping"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 license = "MIT"
 keywords = ["network", "peer-to-peer", "p2p", "ping"]
@@ -10,7 +10,7 @@ description = "ping protocol implementation for tentacle"
 edition = "2018"
 
 [dependencies]
-p2p = { path = "../..", version = "0.2.0-alpha.13", package = "tentacle" }
+p2p = { path = "../..", version = "0.2.0", package = "tentacle" }
 log = "0.4"
 flatbuffers = "0.6.0"
 flatbuffers-verifier = "0.2.0"

--- a/src/service.rs
+++ b/src/service.rs
@@ -49,7 +49,7 @@ pub(crate) const BUF_SHRINK_THRESHOLD: usize = u8::max_value() as usize;
 /// Received from user, aggregate mode
 pub(crate) const RECEIVED_BUFFER_SIZE: usize = 2048;
 /// Use to receive open/close event, no need too large
-pub(crate) const RECEIVED_SIZE: usize = 128;
+pub(crate) const RECEIVED_SIZE: usize = 512;
 /// Send to remote, distribute mode
 pub(crate) const SEND_SIZE: usize = 512;
 pub(crate) const DELAY_TIME: Duration = Duration::from_millis(300);
@@ -1124,7 +1124,7 @@ where
         self.send_future_task(Box::new(task))
     }
 
-    fn start_service_proto_handles(&mut self) {
+    fn init_proto_handles(&mut self) {
         let ids = self
             .protocol_configs
             .values_mut()
@@ -1617,7 +1617,7 @@ where
         if let Some(stream) = self.future_task_manager.take() {
             tokio::spawn(stream.for_each(|_| Ok(())));
             self.notify_queue();
-            self.start_service_proto_handles();
+            self.init_proto_handles();
         }
 
         if !self.write_buf.is_empty()

--- a/src/service/config.rs
+++ b/src/service/config.rs
@@ -1,5 +1,5 @@
 use crate::{
-    builder::{CodecFn, NameFn, SelectVersionFn, SessionHandleFn},
+    builder::{BeforeReceiveFn, CodecFn, NameFn, SelectVersionFn, SessionHandleFn},
     traits::{Codec, ServiceProtocol, SessionProtocol},
     yamux::config::Config as YamuxConfig,
     ProtocolId, SessionId,
@@ -56,6 +56,7 @@ pub struct ProtocolMeta {
     pub(crate) inner: Arc<Meta>,
     pub(crate) service_handle: ProtocolHandle<Box<dyn ServiceProtocol + Send + 'static>>,
     pub(crate) session_handle: SessionHandleFn,
+    pub(crate) before_send: Option<Box<dyn Fn(bytes::Bytes) -> bytes::Bytes + Send + 'static>>,
 }
 
 impl ProtocolMeta {
@@ -122,6 +123,7 @@ pub(crate) struct Meta {
     pub(crate) support_versions: Vec<String>,
     pub(crate) codec: CodecFn,
     pub(crate) select_version: SelectVersionFn,
+    pub(crate) before_receive: BeforeReceiveFn,
 }
 
 /// Protocol handle

--- a/src/session.rs
+++ b/src/session.rs
@@ -444,6 +444,7 @@ where
         };
 
         let proto_id = proto.id;
+        let before_receive_fn = (proto.before_receive)();
         let raw_part = sub_stream.into_parts();
         let mut part = FramedParts::new(raw_part.io, (proto.codec)());
         // Replace buffered data
@@ -465,6 +466,7 @@ where
         .session_proto_sender(self.session_proto_senders.remove(&proto_id))
         .keep_buffer(self.keep_buffer)
         .event(self.event.contains(&proto_id))
+        .before_receive(before_receive_fn)
         .build(frame);
 
         self.sub_streams

--- a/tests/test_before_function.rs
+++ b/tests/test_before_function.rs
@@ -1,0 +1,117 @@
+use bytes::Bytes;
+use futures::prelude::Stream;
+use std::{
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    thread,
+    time::Duration,
+};
+use tentacle::{
+    builder::{MetaBuilder, ServiceBuilder},
+    context::{ProtocolContext, ProtocolContextMutRef},
+    secio::SecioKeyPair,
+    service::{DialProtocol, ProtocolHandle, ProtocolMeta, Service},
+    traits::{ServiceHandle, ServiceProtocol},
+    ProtocolId,
+};
+
+pub fn create<F>(secio: bool, meta: ProtocolMeta, shandle: F) -> Service<F>
+where
+    F: ServiceHandle,
+{
+    let builder = ServiceBuilder::default().insert_protocol(meta);
+
+    if secio {
+        builder
+            .key_pair(SecioKeyPair::secp256k1_generated())
+            .build(shandle)
+    } else {
+        builder.build(shandle)
+    }
+}
+
+struct PHandle;
+
+impl ServiceProtocol for PHandle {
+    fn init(&mut self, _context: &mut ProtocolContext) {}
+
+    fn connected(&mut self, context: ProtocolContextMutRef, _version: &str) {
+        if context.session.ty.is_inbound() {
+            let prefix = "x".repeat(10);
+            let _ = context.send_message(Bytes::from(prefix));
+        }
+    }
+
+    fn disconnected(&mut self, context: ProtocolContextMutRef) {
+        let _ = context.shutdown();
+    }
+
+    fn received(&mut self, context: ProtocolContextMutRef, _data: Bytes) {
+        if context.session.ty.is_outbound() {
+            let _ = context.shutdown();
+        }
+    }
+}
+
+fn create_meta(id: ProtocolId) -> (ProtocolMeta, Arc<AtomicUsize>) {
+    let count = Arc::new(AtomicUsize::new(0));
+    let count_clone = count.clone();
+    let count_clone_1 = count.clone();
+    let meta = MetaBuilder::new()
+        .id(id)
+        .before_send(move |data| {
+            count_clone.fetch_add(1, Ordering::SeqCst);
+            data
+        })
+        .before_receive(move || {
+            let count = count_clone_1.clone();
+            Some(Box::new(move |data: bytes::BytesMut| {
+                count.fetch_add(1, Ordering::SeqCst);
+                Ok(data.freeze())
+            }))
+        });
+
+    (
+        meta.service_handle(move || {
+            if id == 0.into() {
+                ProtocolHandle::Neither
+            } else {
+                let handle = Box::new(PHandle);
+                ProtocolHandle::Callback(handle)
+            }
+        })
+        .build(),
+        count,
+    )
+}
+
+fn test_before_handle(secio: bool) {
+    let (meta, result_1) = create_meta(1.into());
+    let mut service = create(secio, meta, ());
+    let listen_addr = service
+        .listen("/ip4/127.0.0.1/tcp/0".parse().unwrap())
+        .unwrap();
+    thread::spawn(|| tokio::run(service.for_each(|_| Ok(()))));
+    thread::sleep(Duration::from_millis(100));
+
+    let (meta, result_2) = create_meta(1.into());
+    let mut service = create(secio, meta, ());
+    service.dial(listen_addr, DialProtocol::All).unwrap();
+    let handle_2 = thread::spawn(|| tokio::run(service.for_each(|_| Ok(()))));
+    handle_2.join().unwrap();
+
+    assert_eq!(result_1.load(Ordering::SeqCst), 1);
+    assert_eq!(result_2.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn test_before_with_secio() {
+    test_before_handle(true)
+}
+
+#[test]
+fn test_before_with_no_secio() {
+    test_before_handle(false)
+}

--- a/tests/test_block_send_session.rs
+++ b/tests/test_block_send_session.rs
@@ -136,13 +136,14 @@ fn test_block_send(secio: bool, session_protocol: bool) {
     let listen_addr = service
         .listen("/ip4/127.0.0.1/tcp/0".parse().unwrap())
         .unwrap();
-    thread::spawn(|| tokio::run(service.for_each(|_| Ok(()))));
+    thread::spawn(|| tokio::runtime::current_thread::run(service.for_each(|_| Ok(()))));
     thread::sleep(Duration::from_millis(100));
 
     let (meta, result) = create_meta(1.into(), session_protocol);
     let mut service = create(secio, meta, ());
     service.dial(listen_addr, DialProtocol::All).unwrap();
-    let handle_2 = thread::spawn(|| tokio::run(service.for_each(|_| Ok(()))));
+    let handle_2 =
+        thread::spawn(|| tokio::runtime::current_thread::run(service.for_each(|_| Ok(()))));
     handle_2.join().unwrap();
 
     assert_eq!(result.load(Ordering::SeqCst), 512);


### PR DESCRIPTION
Currently, all the handles on the framework are after handles. If you want to use the before operation on the upper layer, it will be very tricky and difficult to maintain.

Just like you want to add a compressed feature to some of the upper layers of the protocol.  The current way of coding can only be as shown in https://github.com/nervosnetwork/ckb/pull/859.

The p2p framework is very different from the web framework in that there is a need for broadcasting. If the function of compressing messages is done in the codec, it will waste a lot of CPU time, because the same message will increase the compression time as the number of connections grows.

We need a unified way of handling broadcast messages, not exactly the same as codec, just like global preprocessing. This pr adds two preprocessing methods for each protocol, which makes it easier to preprocess messages.

Good luck to you

- [x] add before handle
- [x] test