### PR TITLE
chore: Use blocking thread

### DIFF
--- a/secio/Cargo.toml
+++ b/secio/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 bytes = "0.4"
 futures = "0.1"
 tokio = "0.1"
+tokio-threadpool = "0.1"
 log = "0.4.1"
 
 flatbuffers = "0.6.0"

--- a/secio/benches/bench.rs
+++ b/secio/benches/bench.rs
@@ -1,6 +1,6 @@
 use bytes::BytesMut;
 use criterion::{criterion_group, criterion_main, Bencher, Criterion};
-use secio::{
+use tentacle_secio::{
     codec::Hmac,
     stream_cipher::{ctr_init, Cipher},
     Digest,
@@ -45,7 +45,9 @@ fn bench_test(bench: &mut Bencher, cipher: Cipher, data: &[u8]) {
 }
 
 fn criterion_benchmark(bench: &mut Criterion) {
-    let data = (0..1024).map(|_| rand::random::<u8>()).collect::<Vec<_>>();
+    let data = (0..1024 * 256)
+        .map(|_| rand::random::<u8>())
+        .collect::<Vec<_>>();
     bench.bench_function("1kb_aes128", {
         let data = data.clone();
         move |b| bench_test(b, Cipher::Aes128, &data)

--- a/src/protocol_handle_stream.rs
+++ b/src/protocol_handle_stream.rs
@@ -18,6 +18,7 @@ use crate::{
     ProtocolId, SessionId,
 };
 
+#[derive(Clone)]
 pub enum ServiceProtocolEvent {
     Init,
     Connected {
@@ -43,6 +44,9 @@ pub enum ServiceProtocolEvent {
     RemoveNotify {
         token: u64,
     },
+    Notify {
+        token: u64,
+    },
     Update {
         listen_addrs: Vec<Multiaddr>,
     },
@@ -57,6 +61,7 @@ pub struct ServiceProtocolStream<T> {
     notify: HashMap<u64, Duration>,
     notify_sender: mpsc::Sender<u64>,
     notify_receiver: mpsc::Receiver<u64>,
+    current_task: Option<ServiceProtocolEvent>,
     delay: Arc<AtomicBool>,
     shutdown: Arc<AtomicBool>,
     future_task_sender: mpsc::Sender<BoxedFutureTask>,
@@ -82,6 +87,7 @@ where
             notify_sender,
             notify_receiver,
             notify: HashMap::new(),
+            current_task: Some(ServiceProtocolEvent::Init),
             delay: Arc::new(AtomicBool::new(false)),
             shutdown,
             future_task_sender,
@@ -89,13 +95,20 @@ where
     }
 
     #[inline]
-    pub fn handle_event(&mut self, event: ServiceProtocolEvent) {
+    pub fn handle_event(&mut self) -> Async<()> {
         use self::ServiceProtocolEvent::*;
 
+        if self.current_task.is_none() {
+            return Async::Ready(());
+        }
+
         if self.shutdown.load(Ordering::SeqCst) {
-            match event {
+            match self.current_task.as_ref().unwrap() {
                 Disconnected { .. } => (),
-                _ => return,
+                _ => {
+                    self.current_task.take();
+                    return Async::Ready(());
+                }
             }
         }
 
@@ -112,28 +125,62 @@ where
             }
         }
 
-        match event {
+        match self.current_task.clone().unwrap() {
             Init => self.handle.init(&mut self.handle_context),
             Connected { session, version } => {
-                self.handle
-                    .connected(self.handle_context.as_mut(&session), &version);
+                match tokio_threadpool::blocking(|| {
+                    self.handle
+                        .connected(self.handle_context.as_mut(&session), &version)
+                }) {
+                    Ok(Async::Ready(_)) => (),
+                    Ok(Async::NotReady) => return Async::NotReady,
+                    Err(_) => self
+                        .handle
+                        .connected(self.handle_context.as_mut(&session), &version),
+                }
                 self.sessions.insert(session.id, session);
             }
             Disconnected { id } => {
                 if let Some(session) = self.sessions.remove(&id) {
-                    self.handle
-                        .disconnected(self.handle_context.as_mut(&session));
-                }
-            }
-            Received { id, data } => {
-                if let Some(session) = self.sessions.get(&id) {
-                    if !session.closed.load(Ordering::SeqCst) {
+                    match tokio_threadpool::blocking(|| {
                         self.handle
-                            .received(self.handle_context.as_mut(&session), data);
+                            .disconnected(self.handle_context.as_mut(&session))
+                    }) {
+                        Ok(Async::Ready(_)) => (),
+                        Ok(Async::NotReady) => return Async::NotReady,
+                        Err(_) => self
+                            .handle
+                            .disconnected(self.handle_context.as_mut(&session)),
                     }
                 }
             }
-            SetNotify { token, interval } => {
+            Received { id, data } => {
+                if let Some(session) = self.sessions.get(&id).cloned() {
+                    if !session.closed.load(Ordering::SeqCst) {
+                        match tokio_threadpool::blocking(|| {
+                            self.handle
+                                .received(self.handle_context.as_mut(&session), data.clone())
+                        }) {
+                            Ok(Async::Ready(_)) => (),
+                            Ok(Async::NotReady) => return Async::NotReady,
+                            Err(_) => self
+                                .handle
+                                .received(self.handle_context.as_mut(&session), data),
+                        }
+                    }
+                }
+            }
+            Notify { token } => {
+                match tokio_threadpool::blocking(|| {
+                    self.handle.notify(&mut self.handle_context, token)
+                }) {
+                    Ok(Async::Ready(_)) => (),
+                    Ok(Async::NotReady) => return Async::NotReady,
+                    Err(_) => self.handle.notify(&mut self.handle_context, token),
+                }
+                self.set_notify(token);
+            }
+            SetNotify { interval, token } => {
                 self.notify.entry(token).or_insert(interval);
                 self.set_notify(token);
             }
@@ -144,6 +191,8 @@ where
                 self.handle_context.update_listens(listen_addrs);
             }
         }
+        self.current_task.take();
+        Async::Ready(())
     }
 
     fn set_notify(&mut self, token: u64) {
@@ -197,10 +246,19 @@ where
     type Error = ();
 
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        if let Async::NotReady = self.handle_event() {
+            self.set_delay();
+            return Ok(Async::NotReady);
+        }
         let mut finished = false;
         for _ in 0..64 {
             match self.receiver.poll() {
-                Ok(Async::Ready(Some(event))) => self.handle_event(event),
+                Ok(Async::Ready(Some(event))) => {
+                    self.current_task = Some(event);
+                    if let Async::NotReady = self.handle_event() {
+                        break;
+                    }
+                }
                 Ok(Async::Ready(None)) => {
                     debug!(
                         "ServiceProtocolStream({:?}) finished",
@@ -228,8 +286,11 @@ where
         loop {
             match self.notify_receiver.poll() {
                 Ok(Async::Ready(Some(token))) => {
-                    self.handle.notify(&mut self.handle_context, token);
-                    self.set_notify(token);
+                    self.current_task = Some(ServiceProtocolEvent::Notify { token });
+                    if let Async::NotReady = self.handle_event() {
+                        self.set_delay();
+                        break;
+                    }
                 }
                 Ok(Async::Ready(None)) => unreachable!(),
                 Ok(Async::NotReady) => {
@@ -246,12 +307,16 @@ where
             }
         }
 
-        self.handle.poll(&mut self.handle_context);
+        match tokio_threadpool::blocking(|| self.handle.poll(&mut self.handle_context)) {
+            Ok(_) => (),
+            Err(_) => self.handle.poll(&mut self.handle_context),
+        }
 
         Ok(Async::NotReady)
     }
 }
 
+#[derive(Clone)]
 pub enum SessionProtocolEvent {
     Connected {
         version: String,
@@ -261,6 +326,9 @@ pub enum SessionProtocolEvent {
     Received {
         /// Data
         data: bytes::Bytes,
+    },
+    Notify {
+        token: u64,
     },
     SetNotify {
         /// Timer interval
@@ -285,6 +353,7 @@ pub struct SessionProtocolStream<T> {
     notify: HashMap<u64, Duration>,
     notify_sender: mpsc::Sender<u64>,
     notify_receiver: mpsc::Receiver<u64>,
+    current_task: Option<SessionProtocolEvent>,
     delay: Arc<AtomicBool>,
     shutdown: Arc<AtomicBool>,
     future_task_sender: mpsc::Sender<BoxedFutureTask>,
@@ -311,6 +380,7 @@ where
             notify_receiver,
             notify: HashMap::new(),
             context,
+            current_task: None,
             shutdown,
             delay: Arc::new(AtomicBool::new(false)),
             future_task_sender,
@@ -318,33 +388,76 @@ where
     }
 
     #[inline]
-    fn handle_event(&mut self, mut event: SessionProtocolEvent) {
+    fn handle_event(&mut self) -> Async<()> {
         use self::SessionProtocolEvent::*;
 
+        if self.current_task.is_none() {
+            return Async::Ready(());
+        }
         if self.shutdown.load(Ordering::SeqCst) {
-            match event {
+            match self.current_task.as_ref().unwrap() {
                 Disconnected {} => (),
-                _ => return,
+                _ => {
+                    self.current_task.take();
+                    return Async::Ready(());
+                }
             }
         }
 
         if self.context.closed.load(Ordering::SeqCst) {
-            event = SessionProtocolEvent::Disconnected;
+            self.current_task = Some(SessionProtocolEvent::Disconnected);
         }
 
-        match event {
+        match self.current_task.clone().unwrap() {
             Connected { version } => {
-                self.handle
-                    .connected(self.handle_context.as_mut(&self.context), &version);
+                match tokio_threadpool::blocking(|| {
+                    self.handle
+                        .connected(self.handle_context.as_mut(&self.context), &version)
+                }) {
+                    Ok(Async::Ready(_)) => (),
+                    Ok(Async::NotReady) => return Async::NotReady,
+                    Err(_) => self
+                        .handle
+                        .connected(self.handle_context.as_mut(&self.context), &version),
+                }
             }
             Disconnected => {
-                self.handle
-                    .disconnected(self.handle_context.as_mut(&self.context));
+                match tokio_threadpool::blocking(|| {
+                    self.handle
+                        .disconnected(self.handle_context.as_mut(&self.context))
+                }) {
+                    Ok(Async::Ready(_)) => (),
+                    Ok(Async::NotReady) => return Async::NotReady,
+                    Err(_) => self
+                        .handle
+                        .disconnected(self.handle_context.as_mut(&self.context)),
+                }
                 self.close();
             }
             Received { data } => {
-                self.handle
-                    .received(self.handle_context.as_mut(&self.context), data);
+                match tokio_threadpool::blocking(|| {
+                    self.handle
+                        .received(self.handle_context.as_mut(&self.context), data.clone())
+                }) {
+                    Ok(Async::Ready(_)) => (),
+                    Ok(Async::NotReady) => return Async::NotReady,
+                    Err(_) => self
+                        .handle
+                        .received(self.handle_context.as_mut(&self.context), data),
+                }
+            }
+            Notify { token } => {
+                match tokio_threadpool::blocking(|| {
+                    self.handle
+                        .notify(self.handle_context.as_mut(&self.context), token)
+                }) {
+                    Ok(Async::Ready(_)) => (),
+                    Ok(Async::NotReady) => return Async::NotReady,
+                    Err(_) => self
+                        .handle
+                        .notify(self.handle_context.as_mut(&self.context), token),
+                }
+                self.set_notify(token);
             }
             SetNotify { token, interval } => {
                 self.notify.entry(token).or_insert(interval);
@@ -357,6 +470,8 @@ where
                 self.handle_context.update_listens(listen_addrs);
             }
         }
+        self.current_task.take();
+        Async::Ready(())
     }
 
     fn set_notify(&mut self, token: u64) {
@@ -415,9 +530,19 @@ where
     type Error = ();
 
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        if let Async::NotReady = self.handle_event() {
+            self.set_delay();
+            return Ok(Async::NotReady);
+        }
         loop {
             match self.receiver.poll() {
-                Ok(Async::Ready(Some(event))) => self.handle_event(event),
+                Ok(Async::Ready(Some(event))) => {
+                    self.current_task = Some(event);
+                    if let Async::NotReady = self.handle_event() {
+                        self.set_delay();
+                        break;
+                    }
+                }
                 Ok(Async::Ready(None)) => {
                     self.close();
                     return Ok(Async::Ready(None));
@@ -439,9 +564,11 @@ where
         loop {
             match self.notify_receiver.poll() {
                 Ok(Async::Ready(Some(token))) => {
-                    self.handle
-                        .notify(self.handle_context.as_mut(&self.context), token);
-                    self.set_notify(token);
+                    self.current_task = Some(SessionProtocolEvent::Notify { token });
+                    if let Async::NotReady = self.handle_event() {
+                        self.set_delay();
+                        break;
+                    }
                 }
                 Ok(Async::Ready(None)) => unreachable!(),
                 Ok(Async::NotReady) => {
@@ -458,7 +585,12 @@ where
             }
         }
 
-        self.handle.poll(self.handle_context.as_mut(&self.context));
+        match tokio_threadpool::blocking(|| {
+            self.handle.poll(self.handle_context.as_mut(&self.context))
+        }) {
+            Ok(_) => (),
+            Err(_) => self.handle.poll(self.handle_context.as_mut(&self.context)),
+        }
 
         Ok(Async::NotReady)
     }

--- a/src/protocol_handle_stream.rs
+++ b/src/protocol_handle_stream.rs
@@ -307,10 +307,7 @@ where
             }
         }
 
-        match tokio_threadpool::blocking(|| self.handle.poll(&mut self.handle_context)) {
-            Ok(_) => (),
-            Err(_) => self.handle.poll(&mut self.handle_context),
-        }
+        self.handle.poll(&mut self.handle_context);
 
         Ok(Async::NotReady)
     }
@@ -585,12 +582,7 @@ where
             }
         }
 
-        match tokio_threadpool::blocking(|| {
-            self.handle.poll(self.handle_context.as_mut(&self.context))
-        }) {
-            Ok(_) => (),
-            Err(_) => self.handle.poll(self.handle_context.as_mut(&self.context)),
-        }
+        self.handle.poll(self.handle_context.as_mut(&self.context));
 
         Ok(Async::NotReady)
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -534,7 +534,7 @@ where
                     proto_id,
                     (self.shutdown.clone(), self.future_task_sender.clone()),
                 );
-                stream.handle_event(ServiceProtocolEvent::Init);
+                stream.handle_event();
                 tokio::spawn(stream.for_each(|_| Ok(())).map_err(|_| ()));
             }
 


### PR DESCRIPTION
Use blocking thread to avoid the problem that the reactor is not timely

I read some of the source code of `tokio`, repaired the behavior of the thread that we encrypted and decrypted, and also encapsulated the user interface. 

After passing the test, there was no obvious performance degradation.