### PR TITLE
chore: bump to 0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,19 @@
-## 0.2.3 
+## 0.2.4
+
+### Features
+
+- Remove `fnv` dependence
+- Support handshake on molecule with features
+- Handle panic shutdown mechanism
+- Discovery only publish public ip and "0.0.0.0"
+
+### Bug fix
+
+- Fix error output on listen error
+- Fix discovery ipaddr conditions
+- Fix yamux possible security issues on malicious attack
+
+## 0.2.3
 
 ### Features
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tentacle"
-version = "0.2.3"
+version = "0.2.4"
 license = "MIT"
 description = "Minimal implementation for a multiplexed p2p network framework."
 authors = ["piaoliu <441594700@qq.com>", "Nervos Core Dev <dev@nervos.org>"]
@@ -11,9 +11,12 @@ keywords = ["network", "peer-to-peer"]
 categories = ["network-programming", "asynchronous"]
 edition = "2018"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
-yamux = { path = "yamux", version = "0.1.12", package = "tokio-yamux" }
-secio = { path = "secio", version = "0.1.7", package = "tentacle-secio" }
+yamux = { path = "yamux", version = "0.1.13", package = "tokio-yamux" }
+secio = { path = "secio", version = "0.1.10", package = "tentacle-secio" }
 
 futures = "0.1"
 tokio = "0.1"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # P2P
 
 [![Build Status](https://api.travis-ci.org/driftluo/p2p.svg?branch=master)](https://travis-ci.org/driftluo/p2p)
-![image](https://img.shields.io/badge/rustc-1.33-blue.svg)
+![image](https://img.shields.io/badge/rustc-1.36-blue.svg)
 
 ## Overview
 
@@ -38,7 +38,7 @@ The API of this project is basically usable. However we still need more tests. P
 
 ```toml
 [dependencies]
-tentacle = "0.2"
+tentacle = { version = "0.2", feaures = ["molc"] }
 ```
 
 ### Example
@@ -53,13 +53,13 @@ $ git clone https://github.com/nervosnetwork/p2p.git
 
 Listen on 127.0.0.1:1337
 ```bash
-$ RUST_LOG=simple=info,tentacle=debug cargo run --example simple -- server
+$ RUST_LOG=simple=info,tentacle=debug cargo run --example simple --feaures molc -- server
 ```
 
 3. On another terminal:
 
 ```bash
-$ RUST_LOG=simple=info,tentacle=debug cargo run --example simple
+$ RUST_LOG=simple=info,tentacle=debug cargo run --example simple --feaures molc
 ```
 
 4. Now you can see some data interaction information on the terminal.

--- a/protocols/discovery/Cargo.toml
+++ b/protocols/discovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tentacle-discovery"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Linfeng Qian <thewawar@gmail.com>"]
 license = "MIT"
 description = "p2p discovery protocol main reference bitcoin"
@@ -10,7 +10,7 @@ categories = ["network-programming", "asynchronous"]
 edition = "2018"
 
 [dependencies]
-p2p = { path = "../..", version = "0.2.0", package = "tentacle" }
+p2p = { path = "../..", version = "0.2.4", package = "tentacle" }
 bytes = "0.4"
 byteorder = "1.2"
 futures = "0.1"

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tentacle-identify"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Qian Linfeng <thewawar@gmail.com>"]
 license = "MIT"
 description = "p2p identify protocol"
@@ -10,7 +10,7 @@ categories = ["network-programming", "asynchronous"]
 edition = "2018"
 
 [dependencies]
-p2p = { path = "../..", version = "0.2.0", package = "tentacle" }
+p2p = { path = "../..", version = "0.2.4", package = "tentacle" }
 bytes = "0.4"
 flatbuffers = { version = "0.6.0", optional = true }
 flatbuffers-verifier = { version = "0.2.0", optional = true }

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tentacle-ping"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 license = "MIT"
 keywords = ["network", "peer-to-peer", "p2p", "ping"]
@@ -10,7 +10,7 @@ description = "ping protocol implementation for tentacle"
 edition = "2018"
 
 [dependencies]
-p2p = { path = "../..", version = "0.2.0", package = "tentacle" }
+p2p = { path = "../..", version = "0.2.4", package = "tentacle" }
 log = "0.4"
 flatbuffers = { version = "0.6.0", optional = true }
 flatbuffers-verifier = { version = "0.2.0", optional = true }

--- a/secio/Cargo.toml
+++ b/secio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tentacle-secio"
-version = "0.1.9"
+version = "0.1.10"
 license = "MIT"
 description = "Secio encryption protocol for p2p"
 authors = ["piaoliu <441594700@qq.com>", "Nervos Core Dev <dev@nervos.org>"]
@@ -8,6 +8,9 @@ repository = "https://github.com/nervosnetwork/p2p"
 keywords = ["network", "peer-to-peer"]
 categories = ["network-programming", "asynchronous"]
 edition = "2018"
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 bytes = "0.4"

--- a/yamux/Cargo.toml
+++ b/yamux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-yamux"
-version = "0.1.12"
+version = "0.1.13"
 license = "MIT"
 repository = "https://github.com/nervosnetwork/p2p"
 description = "Rust implementation of Yamux"


### PR DESCRIPTION
This is probably the last release of the 0.2 version.

The master branch will start to adapt to the `async` syntax later. Good luck for me.

wait for #179
wait for #180 
wait for #184 