### PR TITLE
revert: handle panic shutdown mechanism

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -1311,6 +1311,14 @@ where
                 remote_address,
                 stream,
             } => self.handshake(stream, SessionType::Outbound, remote_address, None),
+            SessionEvent::ProtocolHandleError { error, proto_id } => {
+                self.handle.handle_error(
+                    &mut self.service_context,
+                    ServiceError::ProtocolHandleError { error, proto_id },
+                );
+                // if handle panic, close service
+                self.handle_service_task(ServiceTask::Shutdown(false));
+            }
         }
     }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -130,6 +130,13 @@ pub(crate) enum SessionEvent {
         id: SessionId,
         error: Error,
     },
+    /// Protocol handle error, will cause memory leaks/abnormal CPU usage
+    ProtocolHandleError {
+        /// Error message
+        error: Error,
+        /// Protocol id
+        proto_id: ProtocolId,
+    },
 }
 
 /// Wrapper for real data streams, such as TCP stream
@@ -547,6 +554,9 @@ where
                     });
                     self.state = SessionState::LocalClose;
                 }
+            }
+            ProtocolEvent::ProtocolHandleError { error, proto_id } => {
+                self.event_output(SessionEvent::ProtocolHandleError { error, proto_id });
             }
         }
     }


### PR DESCRIPTION
In the current implementation, if the user protocol handle panic, the entire service assumes that there is no such protocol and then works "normally".

In the previous version which has a single point performance bottleneck, the user protocol handle panic will shutdown the entire service. But lost this logic in the process of refactoring.

Pretending that the service is "normal" is not a good way to handle it. It makes it difficult for users to find problems with the protocol they are implementing, so I decided to roll back this operation.