### PR TITLE
feat: Aes algorithm hardware acceleration

### DIFF
--- a/secio/Cargo.toml
+++ b/secio/Cargo.toml
@@ -32,13 +32,14 @@ rand = "0.6"
 ring = "0.16.5"
 twofish = "0.2.0"
 aes-ctr = "0.3.0"
+aesni = { version = "0.6", default-features = false, features = ["nocheck"] }
 ctr = "0.3.0"
 unsigned-varint = "0.2.2"
 bs58 = "0.2.0"
 
 [dev-dependencies]
 env_logger = "0.6"
-criterion = "0.2"
+criterion = "0.3"
 
 [features]
 default = []

--- a/tests/test_kill.rs
+++ b/tests/test_kill.rs
@@ -17,10 +17,10 @@ use tentacle::{
 };
 
 /// Get current used memory(bytes)
-fn current_used_memory() -> Option<f32> {
+fn current_used_memory() -> Option<f64> {
     let sys = System::new();
     match sys.memory() {
-        Ok(mem) => Some((mem.total.as_usize() - mem.free.as_usize()) as f32),
+        Ok(mem) => Some((mem.total.as_u64() - mem.free.as_u64()) as f64),
         Err(_) => None,
     }
 }


### PR DESCRIPTION
On my machine：
```bash
$ cat /proc/cpuinfo | grep name | cut -f2 -d: | uniq -c
      8  Intel(R) Core(TM) i7-6700HQ CPU @ 2.60GHz
```

before：

```
1kb_aes128              time:   [9.4003 ms 9.4581 ms 9.5252 ms]                        
                        change: [+4.0887% +5.0088% +5.9171%] (p = 0.00 < 0.05)
                        Performance has regressed.
1kb_aes256              time:   [11.567 ms 11.638 ms 11.712 ms]                        
                        change: [+0.8615% +1.9225% +2.8798%] (p = 0.00 < 0.05)
                        Change within noise threshold.
1mb_aes128              time:   [36.289 ms 36.395 ms 36.521 ms]                        
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
1mb_aes256              time:   [46.033 ms 46.292 ms 46.606 ms]                        
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```

after：
```
1kb_aes128              time:   [3.3078 ms 3.3222 ms 3.3390 ms]                        
                        change: [-65.736% -65.394% -65.066%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  9 (9.00%) high mild
  1 (1.00%) high severe
1kb_aes256              time:   [3.5324 ms 3.5444 ms 3.5574 ms]                        
                        change: [-69.653% -69.430% -69.212%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
1mb_aes128              time:   [13.379 ms 13.430 ms 13.486 ms]                        
                        change: [-63.624% -63.383% -63.125%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe
1mb_aes256              time:   [14.268 ms 14.306 ms 14.345 ms]                        
                        change: [-69.442% -69.242% -69.047%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```
