### PR TITLE
fix: add transport connection number limit on listener

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -122,6 +122,16 @@ impl ServiceBuilder {
         self
     }
 
+    /// The limit of max open connection(file descriptors)
+    /// If not limited, service will try to serve as many connections as possible until it exhausts system resources(os error),
+    /// and then close the listener, no longer accepting new connection requests, and the established connections remain working
+    ///
+    /// Default is 65535
+    pub fn max_connection_number(mut self, number: usize) -> Self {
+        self.config.max_connection_number = number;
+        self
+    }
+
     /// Clear all protocols
     pub fn clear(&mut self) {
         self.inner.clear();

--- a/src/service.rs
+++ b/src/service.rs
@@ -1503,6 +1503,17 @@ where
     /// Poll listen connections
     #[inline]
     fn listen_poll(&mut self) {
+        if !self
+            .listens
+            .len()
+            .checked_add(self.sessions.len())
+            .and_then(|count| count.checked_add(self.state.into_inner().unwrap_or_default()))
+            .map(|count| self.config.max_connection_number >= count)
+            .unwrap_or_default()
+        {
+            return;
+        }
+
         let mut update = false;
         for (address, mut listen) in self.listens.split_off(0) {
             match listen.poll() {

--- a/src/service/config.rs
+++ b/src/service/config.rs
@@ -16,6 +16,7 @@ pub(crate) struct ServiceConfig {
     pub event: HashSet<ProtocolId>,
     pub keep_buffer: bool,
     pub upnp: bool,
+    pub max_connection_number: usize,
 }
 
 impl Default for ServiceConfig {
@@ -27,6 +28,7 @@ impl Default for ServiceConfig {
             event: HashSet::default(),
             keep_buffer: false,
             upnp: false,
+            max_connection_number: 65535,
         }
     }
 }
@@ -297,6 +299,14 @@ impl State {
         match self {
             State::Running(num) => *num -= 1,
             State::PreShutdown | State::Forever => (),
+        }
+    }
+
+    #[inline]
+    pub fn into_inner(self) -> Option<usize> {
+        match self {
+            State::Running(num) => Some(num),
+            State::PreShutdown | State::Forever => None,
         }
     }
 }


### PR DESCRIPTION
Tentacle has not previously made any restrictions on the number of transport connections, which may lead to fd attacks. The good news is that the consequence of the fd attack is only that the listening service will be closed, and it will not affect the established connection. But we should fix it.

The fd create on [std::sys::net](https://doc.rust-lang.org/nightly/src/std/sys/unix/net.rs.html#192-223), and it will call by `tokio::tcplistener::poll_accpet`, their calling relationship is as follows:

tokio -> mio -> std net -> std sys common -> std sys net -> std sys fd -> syscall