### PR TITLE
[ᚬuse-async-await] feat: remove libc dep on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,13 @@ molecule = { version = "0.4.0", optional = true }
 
 # upnp
 igd = "0.9"
-libc = "0.2"
+
+[target.'cfg(unix)'.dependencies.libc]
+version = "0.2"
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3.7"
-features = ["minwindef", "ws2def", "winerror"]
+features = ["minwindef", "ws2def", "winerror", "heapapi"]
 
 [dev-dependencies]
 env_logger = "0.6.0"


### PR DESCRIPTION
Use winapi's heap* series of interfaces to allocate and clean up memory on win, thereby removing `libc` dependencies