### PR TITLE
fix: Fix throughput issues caused by code limit

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -1700,8 +1700,7 @@ where
 
     #[inline]
     fn user_task_poll(&mut self, cx: &mut Context) {
-        let mut finished = false;
-        for _ in 0..512 {
+        loop {
             if self.write_buf.len() > self.config.session_config.send_event_size()
                 && self.high_write_buf.len() > self.config.session_config.send_event_size()
             {
@@ -1746,19 +1745,14 @@ where
             match task {
                 Some(task) => self.handle_service_task(cx, task),
                 None => {
-                    finished = true;
                     break;
                 }
             }
         }
-        if !finished {
-            self.set_delay(cx);
-        }
     }
 
     fn session_poll(&mut self, cx: &mut Context) {
-        let mut finished = false;
-        for _ in 0..64 {
+        loop {
             if self.read_service_buf.len() > self.config.session_config.recv_event_size()
                 || self.read_session_buf.len() > self.config.session_config.recv_event_size()
             {
@@ -1772,13 +1766,9 @@ where
                 Poll::Ready(Some(event)) => self.handle_session_event(cx, event),
                 Poll::Ready(None) => unreachable!(),
                 Poll::Pending => {
-                    finished = true;
                     break;
                 }
             }
-        }
-        if !finished {
-            self.set_delay(cx);
         }
     }
 

--- a/src/substream.rs
+++ b/src/substream.rs
@@ -396,8 +396,7 @@ where
     }
 
     fn recv_frame(&mut self, cx: &mut Context) {
-        let mut finished = false;
-        for _ in 0..64 {
+        loop {
             if self.dead {
                 break;
             }
@@ -459,11 +458,9 @@ where
                     return;
                 }
                 Poll::Pending => {
-                    finished = true;
                     break;
                 }
                 Poll::Ready(Some(Err(err))) => {
-                    finished = true;
                     debug!("sub stream codec error: {:?}", err);
                     match err.kind() {
                         ErrorKind::BrokenPipe
@@ -478,9 +475,6 @@ where
                     }
                 }
             }
-        }
-        if !finished {
-            self.set_delay(cx);
         }
     }
 

--- a/yamux/Cargo.toml
+++ b/yamux/Cargo.toml
@@ -17,3 +17,4 @@ log = "0.4"
 [dev-dependencies]
 env_logger = "0.6"
 rand = "0.6"
+bytesize = "1"

--- a/yamux/examples/throughput_test.rs
+++ b/yamux/examples/throughput_test.rs
@@ -1,0 +1,157 @@
+use bytesize::ByteSize;
+use futures::prelude::*;
+use log::{info, warn};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+    time::delay_for,
+};
+use tokio_yamux::stream::StreamHandle;
+use tokio_yamux::{config::Config, session::Session};
+
+fn main() {
+    env_logger::init();
+    if std::env::args().nth(1) == Some("server".to_string()) {
+        info!("Starting server ......");
+        run_server();
+    } else {
+        info!("Starting client ......");
+        run_client();
+    }
+}
+
+const STR: &str = "fakeu1234567890cmxcmmmmmmmmmsssmssmsmsmxcmcmcnxzlllslsllcccccsannmxmxmxmxmxmxmxmxmmsssjjkzoso.";
+const LEN: usize = STR.len();
+
+static REQC: AtomicUsize = AtomicUsize::new(0);
+static RESPC: AtomicUsize = AtomicUsize::new(0);
+
+use std::{
+    str,
+    sync::atomic::{AtomicUsize, Ordering},
+    time::Duration,
+};
+
+fn reqc_incr() -> usize {
+    REQC.fetch_add(1, Ordering::Relaxed)
+}
+
+fn reqc() -> usize {
+    REQC.swap(0, Ordering::SeqCst)
+}
+
+fn respc_incr() -> usize {
+    RESPC.fetch_add(1, Ordering::Relaxed)
+}
+
+fn respc() -> usize {
+    RESPC.swap(0, Ordering::SeqCst)
+}
+
+async fn show_metric() {
+    let secs = 10;
+    loop {
+        delay_for(Duration::from_millis(1000 * secs)).await;
+        let reqc = reqc();
+        let respc = respc();
+        info!(
+            "{} secs req {}, resp {}; {} req/s, {}/s; {} resp/s {}/s",
+            secs,
+            reqc,
+            respc,
+            reqc as f64 / secs as f64,
+            ByteSize::b(((reqc * LEN) as f64 / secs as f64) as u64).to_string_as(true),
+            respc as f64 / secs as f64,
+            ByteSize::b(((respc * LEN) as f64 / secs as f64) as u64).to_string_as(true),
+        );
+    }
+}
+
+fn run_server() {
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+
+    rt.spawn(show_metric());
+
+    rt.block_on(async move {
+        let mut listener = TcpListener::bind("127.0.0.1:12345").await.unwrap();
+
+        while let Ok((socket, _)) = listener.accept().await {
+            info!("accepted a socket: {:?}", socket.peer_addr());
+            let mut session = Session::new_server(socket, Config::default());
+            tokio::spawn(async move {
+                while let Some(Ok(mut stream)) = session.next().await {
+                    info!("Server accept a stream from client: id={}", stream.id());
+                    tokio::spawn(async move {
+                        let mut data = [0u8; LEN];
+                        stream.read_exact(&mut data).await.unwrap();
+                        assert_eq!(data.as_ref(), STR.as_bytes());
+
+                        loop {
+                            stream.write_all(STR.as_bytes()).await.unwrap();
+                            respc_incr();
+
+                            stream.read_exact(&mut data).await.unwrap();
+                            reqc_incr();
+
+                            assert_eq!(data.as_ref(), STR.as_bytes());
+                        }
+                    });
+                }
+            });
+        }
+    });
+}
+
+fn run_client() {
+    let num = std::env::args()
+        .nth(1)
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(2);
+
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+
+    rt.block_on(async move {
+        let socket = TcpStream::connect("127.0.0.1:12345").await.unwrap();
+        let sa = socket.peer_addr().unwrap();
+        info!("[client] connected to server: {:?}", sa);
+
+        let mut session = Session::new_client(socket, Config::default());
+        let streams = (0..num)
+            .into_iter()
+            .map(|_| session.open_stream().unwrap())
+            .collect::<Vec<_>>();
+
+        tokio::spawn(async move {
+            loop {
+                match session.next().await {
+                    Some(res) => warn!("res: {:?}", res),
+                    None => break,
+                }
+            }
+            warn!("{:?} broken", sa);
+        });
+
+        let f = |mut s: StreamHandle| {
+            tokio::spawn(async move {
+                s.write_all(STR.as_bytes()).await.unwrap();
+
+                let mut data = [0u8; LEN];
+
+                loop {
+                    s.read_exact(&mut data).await.unwrap();
+                    assert_eq!(data.as_ref(), STR.as_bytes());
+                    respc_incr();
+
+                    s.write_all(STR.as_bytes()).await.unwrap();
+                    reqc_incr();
+                }
+            })
+        };
+
+        for stream in streams {
+            f(stream);
+        }
+
+        show_metric().await;
+    });
+}

--- a/yamux/src/session.rs
+++ b/yamux/src/session.rs
@@ -484,7 +484,7 @@ where
 
     // Receive frames from low level stream
     fn recv_frames(&mut self, cx: &mut Context) -> Result<(), io::Error> {
-        for _ in 0..64 {
+        loop {
             if self.is_dead() {
                 return Ok(());
             }
@@ -508,8 +508,6 @@ where
                 }
             }
         }
-        self.set_delay(cx);
-        Ok(())
     }
 
     fn handle_event(&mut self, cx: &mut Context, event: StreamEvent) -> Result<(), io::Error> {
@@ -542,7 +540,7 @@ where
     // Receive events from sub streams
     // TODO: should handle error
     fn recv_events(&mut self, cx: &mut Context) -> Result<(), io::Error> {
-        for _ in 0..64 {
+        loop {
             if self.is_dead() {
                 return Ok(());
             }
@@ -559,8 +557,6 @@ where
                 }
             }
         }
-        self.set_delay(cx);
-        Ok(())
     }
 
     #[inline]


### PR DESCRIPTION
There is a throughput issue. Although it was not warned in the current project, it is indeed a bug.

This bug is reported by @biluohc, thanks for his work, and his test data is:

![image](https://user-images.githubusercontent.com/19374080/76844346-1bcceb00-6878-11ea-8162-776b088d3e78.png)

**When sub-stream opens more than 64, the throughput plummets**

In this PR, I brought a test case that can be used to detect the effect. Of course, I will also post the test data here.

The number means how many sub-stream the test open

On my machine:

before:
```shell
$ env RUST_LOG=info ../target/release/examples/throughput_test 60
[2020-03-17T09:34:41Z INFO  throughput_test] 10 secs req 2199349, resp 2199382; 219934.9 req/s, 19.7 MiB/s; 219938.2 resp/s 19.7 MiB/s
[2020-03-17T09:34:51Z INFO  throughput_test] 10 secs req 2084170, resp 2084170; 208417 req/s, 18.7 MiB/s; 208417 resp/s 18.7 MiB/s
[2020-03-17T09:35:01Z INFO  throughput_test] 10 secs req 2176809, resp 2176809; 217680.9 req/s, 19.5 MiB/s; 217680.9 resp/s 19.5 MiB/s
[2020-03-17T09:35:11Z INFO  throughput_test] 10 secs req 2244738, resp 2244738; 224473.8 req/s, 20.1 MiB/s; 224473.8 resp/s 20.1 MiB/s
[2020-03-17T09:35:21Z INFO  throughput_test] 10 secs req 2244576, resp 2244576; 224457.6 req/s, 20.1 MiB/s; 224457.6 resp/s 20.1 MiB/s

$ env RUST_LOG=info ../target/release/examples/throughput_test 70
[2020-03-17T09:43:06Z INFO  throughput_test] 10 secs req 2274972, resp 2275010; 227497.2 req/s, 20.4 MiB/s; 227501 resp/s 20.4 MiB/s
[2020-03-17T09:43:16Z INFO  throughput_test] 10 secs req 2040372, resp 2040372; 204037.2 req/s, 18.3 MiB/s; 204037.2 resp/s 18.3 MiB/s
[2020-03-17T09:43:26Z INFO  throughput_test] 10 secs req 2151312, resp 2151312; 215131.2 req/s, 19.3 MiB/s; 215131.2 resp/s 19.3 MiB/s
[2020-03-17T09:43:36Z INFO  throughput_test] 10 secs req 2158892, resp 2158892; 215889.2 req/s, 19.4 MiB/s; 215889.2 resp/s 19.4 MiB/s
[2020-03-17T09:43:46Z INFO  throughput_test] 10 secs req 2157059, resp 2157059; 215705.9 req/s, 19.3 MiB/s; 215705.9 resp/s 19.3 MiB/s

$ env RUST_LOG=info ../target/release/examples/throughput_test 150
[2020-03-17T09:56:21Z INFO  throughput_test] 10 secs req 2165861, resp 2165928; 216586.1 req/s, 19.4 MiB/s; 216592.8 resp/s 19.4 MiB/s
[2020-03-17T09:56:31Z INFO  throughput_test] 10 secs req 2031211, resp 2031212; 203121.1 req/s, 18.2 MiB/s; 203121.2 resp/s 18.2 MiB/s
[2020-03-17T09:56:41Z INFO  throughput_test] 10 secs req 1961369, resp 1961369; 196136.9 req/s, 17.6 MiB/s; 196136.9 resp/s 17.6 MiB/s
[2020-03-17T09:56:51Z INFO  throughput_test] 10 secs req 2106573, resp 2106573; 210657.3 req/s, 18.9 MiB/s; 210657.3 resp/s 18.9 MiB/s
[2020-03-17T09:57:01Z INFO  throughput_test] 10 secs req 2172906, resp 2172906; 217290.6 req/s, 19.5 MiB/s; 217290.6 resp/s 19.5 MiB/s

$ env RUST_LOG=info ../target/release/examples/throughput_test 200
[2020-03-17T09:47:19Z INFO  throughput_test] 10 secs req 2327, resp 2373; 232.7 req/s, 21.4 kiB/s; 237.3 resp/s 21.8 kiB/s
[2020-03-17T09:47:29Z INFO  throughput_test] 10 secs req 2112, resp 2112; 211.2 req/s, 19.4 kiB/s; 211.2 resp/s 19.4 kiB/s
[2020-03-17T09:47:39Z INFO  throughput_test] 10 secs req 2176, resp 2176; 217.6 req/s, 20.0 kiB/s; 217.6 resp/s 20.0 kiB/s
[2020-03-17T09:47:49Z INFO  throughput_test] 10 secs req 7696, resp 7696; 769.6 req/s, 70.6 kiB/s; 769.6 resp/s 70.6 kiB/s
[2020-03-17T09:47:59Z INFO  throughput_test] 10 secs req 2112, resp 2112; 211.2 req/s, 19.4 kiB/s; 211.2 resp/s 19.4 kiB/s
```
**When 200 sub-streams are reached, the throughput also collapses**

After fix:
```shell
$ env RUST_LOG=info ../target/release/examples/throughput_test 200
[2020-03-17T09:59:33Z INFO  throughput_test] 10 secs req 2294090, resp 2294153; 229409 req/s, 20.6 MiB/s; 229415.3 resp/s 20.6 MiB/s
[2020-03-17T09:59:43Z INFO  throughput_test] 10 secs req 2182031, resp 2182031; 218203.1 req/s, 19.6 MiB/s; 218203.1 resp/s 19.6 MiB/s
[2020-03-17T09:59:53Z INFO  throughput_test] 10 secs req 2194474, resp 2194474; 219447.4 req/s, 19.7 MiB/s; 219447.4 resp/s 19.7 MiB/s
[2020-03-17T10:00:03Z INFO  throughput_test] 10 secs req 2197789, resp 2197789; 219778.9 req/s, 19.7 MiB/s; 219778.9 resp/s 19.7 MiB/s
[2020-03-17T10:00:13Z INFO  throughput_test] 10 secs req 2185227, resp 2185227; 218522.7 req/s, 19.6 MiB/s; 218522.7 resp/s 19.6 MiB/s

$ env RUST_LOG=info ../target/release/examples/throughput_test 20000
[2020-03-17T10:01:00Z INFO  throughput_test] 10 secs req 2200967, resp 2220919; 220096.7 req/s, 19.7 MiB/s; 222091.9 resp/s 19.9 MiB/s
[2020-03-17T10:01:10Z INFO  throughput_test] 10 secs req 2239152, resp 2239152; 223915.2 req/s, 20.1 MiB/s; 223915.2 resp/s 20.1 MiB/s
[2020-03-17T10:01:20Z INFO  throughput_test] 10 secs req 2245582, resp 2245582; 224558.2 req/s, 20.1 MiB/s; 224558.2 resp/s 20.1 MiB/s
[2020-03-17T10:01:30Z INFO  throughput_test] 10 secs req 2227042, resp 2227043; 222704.2 req/s, 20.0 MiB/s; 222704.3 resp/s 20.0 MiB/s
[2020-03-17T10:01:40Z INFO  throughput_test] 10 secs req 2159182, resp 2159182; 215918.2 req/s, 19.4 MiB/s; 215918.2 resp/s 19.4 MiB/s

$ env RUST_LOG=info ../target/release/examples/throughput_test 200000
[2020-03-17T10:02:17Z INFO  throughput_test] 10 secs req 1465293, resp 1665248; 146529.3 req/s, 13.1 MiB/s; 166524.8 resp/s 14.9 MiB/s
[2020-03-17T10:02:27Z INFO  throughput_test] 10 secs req 2143520, resp 2143520; 214352 req/s, 19.2 MiB/s; 214352 resp/s 19.2 MiB/s
[2020-03-17T10:02:37Z INFO  throughput_test] 10 secs req 2166556, resp 2166556; 216655.6 req/s, 19.4 MiB/s; 216655.6 resp/s 19.4 MiB/s
[2020-03-17T10:02:47Z INFO  throughput_test] 10 secs req 2160291, resp 2160291; 216029.1 req/s, 19.4 MiB/s; 216029.1 resp/s 19.4 MiB/s
[2020-03-17T10:02:57Z INFO  throughput_test] 10 secs req 2172042, resp 2172042; 217204.2 req/s, 19.5 MiB/s; 217204.2 resp/s 19.5 MiB/s
[2020-03-17T10:03:07Z INFO  throughput_test] 10 secs req 2175055, resp 2175055; 217505.5 req/s, 19.5 MiB/s; 217505.5 resp/s 19.5 MiB/s

$ env RUST_LOG=info ../target/release/examples/throughput_test 2000000
[2020-03-17T10:03:46Z INFO  throughput_test] 10 secs req 0, resp 0; 0 req/s, 0 B/s; 0 resp/s 0 B/s
[2020-03-17T10:03:56Z INFO  throughput_test] 10 secs req 0, resp 0; 0 req/s, 0 B/s; 0 resp/s 0 B/s
[2020-03-17T10:04:09Z INFO  throughput_test] 10 secs req 80, resp 2000032; 8 req/s, 752 B/s; 200003.2 resp/s 17.9 MiB/s
[2020-03-17T10:04:19Z INFO  throughput_test] 10 secs req 2249144, resp 2249164; 224914.4 req/s, 20.2 MiB/s; 224916.4 resp/s 20.2 MiB/s
[2020-03-17T10:04:29Z INFO  throughput_test] 10 secs req 2219493, resp 2219493; 221949.3 req/s, 19.9 MiB/s; 221949.3 resp/s 19.9 MiB/s
[2020-03-17T10:04:39Z INFO  throughput_test] 10 secs req 2228510, resp 2228510; 222851 req/s, 20.0 MiB/s; 222851 resp/s 20.0 MiB/s
[2020-03-17T10:04:49Z INFO  throughput_test] 10 secs req 2213271, resp 2213271; 221327.1 req/s, 19.8 MiB/s; 221327.1 resp/s 19.8 MiB/s
[2020-03-17T10:04:59Z INFO  throughput_test] 10 secs req 2231752, resp 2231752; 223175.2 req/s, 20.0 MiB/s; 223175.2 resp/s 20.0 MiB/s
```

After this fix, under 2000000 sub-streams, the throughput remains normal without a collapse.

The problem this time was that it interfered with the normal Reacter-Executor scheduling and execution, resulting in avalanche-like consequences.