### PR TITLE
fix: Fix FutureTask signals memory leak

### DIFF
--- a/src/service/future_task.rs
+++ b/src/service/future_task.rs
@@ -63,7 +63,7 @@ impl FutureTaskManager {
         tokio::spawn(async move {
             future::select(task, receiver).await;
             trace!("future task({}) finished", task_id);
-            let _ = id_sender.send(task_id);
+            let _ = id_sender.send(task_id).await;
         });
     }
 


### PR DESCRIPTION
`oneshot::Sender.send()` return a `Future`, we must use `.await` to poll it.