### PR TITLE
fix: fix session proto open/close by user part

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -480,7 +480,7 @@ where
         .stream_id(self.next_stream)
         .config(self.config)
         .service_proto_sender(self.service_proto_senders.get(&proto_id).cloned())
-        .session_proto_sender(self.session_proto_senders.remove(&proto_id))
+        .session_proto_sender(self.session_proto_senders.get(&proto_id).cloned())
         .keep_buffer(self.keep_buffer)
         .event(self.event.contains(&proto_id))
         .before_receive(before_receive_fn)
@@ -632,16 +632,16 @@ where
                 }
             }
             SessionEvent::ProtocolClose { proto_id, .. } => {
-                if !self.proto_streams.contains_key(&proto_id) {
-                    debug!("proto [{}] has been closed", proto_id);
-                } else {
+                if let Some(stream_id) = self.proto_streams.get(&proto_id) {
                     self.write_buf.push_back((
                         proto_id,
                         ProtocolEvent::Close {
-                            id: self.proto_streams[&proto_id],
+                            id: *stream_id,
                             proto_id,
                         },
                     ));
+                } else {
+                    debug!("proto [{}] has been closed", proto_id);
                 }
             }
             _ => (),

--- a/src/substream.rs
+++ b/src/substream.rs
@@ -121,7 +121,7 @@ where
 
         if self.session_proto_sender.is_some() {
             self.session_proto_buf
-                .push_back(SessionProtocolEvent::Connected { version })
+                .push_back(SessionProtocolEvent::Opened { version })
         }
     }
 
@@ -227,7 +227,13 @@ where
 
         if self.session_proto_sender.is_some() {
             self.session_proto_buf
-                .push_back(SessionProtocolEvent::Disconnected);
+                .push_back(SessionProtocolEvent::Closed);
+
+            if self.closed.load(Ordering::SeqCst) {
+                self.session_proto_buf
+                    .push_back(SessionProtocolEvent::Disconnected);
+            }
+
             let events = self.session_proto_buf.split_off(0);
             let mut sender = self.session_proto_sender.take().unwrap();
             tokio::spawn(async move {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -58,7 +58,7 @@ pub trait ServiceHandle {
 /// to the session, but the service handle will remain in the state until the service is closed.
 ///
 pub trait ServiceProtocol {
-    /// This function is called when the protocol is opened.
+    /// This function is called when the service start.
     ///
     /// The service handle will only be called once
     fn init(&mut self, context: &mut ProtocolContext);


### PR DESCRIPTION
This is a long-established bug that only affects the manual opening of the user's protocol at the session-level.

There's a logical confusion here, the handle doesn't need to be open every time it's open, because the session is already resident when it's open. The handle does not need to be removed when the protocol is closed alone, but only when the session is closed.

Now, with the addition of a test case here.