### PR TITLE
chore: upgrade tokio util

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ secio = { path = "secio", version = "0.3.1", package = "tentacle-secio" }
 
 futures = { version = "0.3.0" }
 tokio = { version = "0.2.0", features = ["time", "io-util", "tcp", "dns", "rt-threaded", "blocking"] }
-tokio-util = { version = "0.2.0", features = ["codec"] }
+tokio-util = { version = "0.3.0", features = ["codec"] }
 log = "0.4"
 bytes = "0.5.0"
 

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -16,7 +16,7 @@ p2p = { path = "..", package = "tentacle" }
 rand = "0.6.1"
 futures = { version = "0.3.0" }
 tokio = { version = "0.2.0", features = ["time", "io-util", "tcp", "dns", "rt-threaded", "blocking"] }
-tokio-util = { version = "0.2.0", features = ["codec"] }
+tokio-util = { version = "0.3.0", features = ["codec"] }
 crossbeam-channel = "0.3.6"
 env_logger = "0.6.0"
 bytes = "0.5.0"

--- a/secio/Cargo.toml
+++ b/secio/Cargo.toml
@@ -19,7 +19,7 @@ no-default-features = true
 bytes = "0.5"
 futures = { version = "0.3.0" }
 tokio = { version = "0.2.0", features = ["time", "io-util", "tcp", "dns"] }
-tokio-util = { version = "0.2.0", features = ["codec"] }
+tokio-util = { version = "0.3.0", features = ["codec"] }
 log = "0.4.1"
 
 flatbuffers = { version = "0.6.0", optional = true }

--- a/secio/src/codec/secure_stream.rs
+++ b/secio/src/codec/secure_stream.rs
@@ -152,7 +152,6 @@ where
             }
             StreamEvent::Close => {
                 self.dead = true;
-                let _ = self.socket.close();
             }
             StreamEvent::Flush => {
                 self.flush(cx)?;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -92,13 +92,13 @@ pub trait SessionProtocol {
 
 /// A trait can define codec, just wrapper `Decoder` and `Encoder`
 pub trait Codec:
-    Decoder<Item = bytes::BytesMut, Error = io::Error> + Encoder<Item = bytes::Bytes, Error = io::Error>
+    Decoder<Item = bytes::BytesMut, Error = io::Error> + Encoder<bytes::Bytes, Error = io::Error>
 {
 }
 
 impl<T> Codec for T where
     T: Decoder<Item = bytes::BytesMut, Error = io::Error>
-        + Encoder<Item = bytes::Bytes, Error = io::Error>
+        + Encoder<bytes::Bytes, Error = io::Error>
 {
 }
 
@@ -111,11 +111,10 @@ impl Decoder for Box<dyn Codec + Send + 'static> {
     }
 }
 
-impl Encoder for Box<dyn Codec + Send + 'static> {
-    type Item = bytes::Bytes;
+impl Encoder<bytes::Bytes> for Box<dyn Codec + Send + 'static> {
     type Error = io::Error;
 
-    fn encode(&mut self, item: Self::Item, dst: &mut bytes::BytesMut) -> Result<(), Self::Error> {
+    fn encode(&mut self, item: bytes::Bytes, dst: &mut bytes::BytesMut) -> Result<(), Self::Error> {
         Encoder::encode(&mut **self, item, dst)
     }
 }

--- a/yamux/Cargo.toml
+++ b/yamux/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 bytes = "0.5.0"
 futures = { version = "0.3.0" }
 tokio = { version = "0.2.0", features = ["time", "io-util", "tcp", "dns"] }
-tokio-util = { version = "0.2.0", features = ["codec"] }
+tokio-util = { version = "0.3.0", features = ["codec"] }
 log = "0.4"
 
 [dev-dependencies]

--- a/yamux/src/frame.rs
+++ b/yamux/src/frame.rs
@@ -329,10 +329,9 @@ impl Decoder for FrameCodec {
     }
 }
 
-impl Encoder for FrameCodec {
-    type Item = Frame;
+impl Encoder<Frame> for FrameCodec {
     type Error = io::Error;
-    fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
+    fn encode(&mut self, item: Frame, dst: &mut BytesMut) -> Result<(), Self::Error> {
         // Must ensure that there is enough space in the buf
         dst.reserve(item.size());
         let (header, body) = item.into_parts();


### PR DESCRIPTION
tokio-util:

1. api break change
2. Use advance over split_to when data is not needed