### PR TITLE
feat: use flag to control how to use `block_in_place`

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -6,7 +6,7 @@ use crate::{
     protocol_select::SelectFn,
     secio::SecioKeyPair,
     service::{
-        config::{Meta, ServiceConfig},
+        config::{BlockingFlag, Meta, ServiceConfig},
         ProtocolHandle, ProtocolMeta, Service,
     },
     traits::{Codec, ServiceHandle, ServiceProtocol, SessionProtocol},
@@ -177,6 +177,7 @@ pub struct MetaBuilder {
     select_version: SelectVersionFn,
     before_send: Option<Box<dyn Fn(bytes::Bytes) -> bytes::Bytes + Send + 'static>>,
     before_receive: BeforeReceiveFn,
+    flag: BlockingFlag,
 }
 
 impl MetaBuilder {
@@ -277,6 +278,12 @@ impl MetaBuilder {
         self
     }
 
+    /// Set a flag to control function behavior
+    pub fn flag(mut self, flag: BlockingFlag) -> Self {
+        self.flag = flag;
+        self
+    }
+
     /// Combine the configuration of this builder to create a ProtocolMeta
     pub fn build(self) -> ProtocolMeta {
         let meta = Meta {
@@ -292,6 +299,7 @@ impl MetaBuilder {
             service_handle: self.service_handle,
             session_handle: self.session_handle,
             before_send: self.before_send,
+            flag: self.flag,
         }
     }
 }
@@ -308,6 +316,7 @@ impl Default for MetaBuilder {
             select_version: Box::new(|| None),
             before_send: None,
             before_receive: Box::new(|| None),
+            flag: BlockingFlag::default(),
         }
     }
 }

--- a/src/service/config.rs
+++ b/src/service/config.rs
@@ -121,6 +121,7 @@ pub struct ProtocolMeta {
     pub(crate) service_handle: ProtocolHandle<Box<dyn ServiceProtocol + Send + 'static + Unpin>>,
     pub(crate) session_handle: SessionHandleFn,
     pub(crate) before_send: Option<Box<dyn Fn(bytes::Bytes) -> bytes::Bytes + Send + 'static>>,
+    pub(crate) flag: BlockingFlag,
 }
 
 impl ProtocolMeta {
@@ -182,6 +183,11 @@ impl ProtocolMeta {
         &mut self,
     ) -> ProtocolHandle<Box<dyn SessionProtocol + Send + 'static + Unpin>> {
         (self.session_handle)()
+    }
+
+    /// Control whether the protocol handle method requires blocking to run
+    pub fn blocking_flag(&self) -> BlockingFlag {
+        self.flag
     }
 }
 
@@ -254,6 +260,83 @@ impl<T> ProtocolHandle<T> {
     }
 }
 
+/// Control whether the protocol handle method requires blocking to run
+/// default is 0b1111, all function use blocking
+///
+/// flag & 0b1000 > 0 means `connected` use blocking
+/// flag & 0b0100 > 0 means `disconnected` use blocking
+/// flag & 0b0010 > 0 means `received` use blocking
+/// flag & 0b0001 > 0 means `notify` use blocking
+#[derive(Copy, Clone, Debug)]
+pub struct BlockingFlag(u8);
+
+impl BlockingFlag {
+    /// connected don't use blocking
+    #[inline]
+    pub fn disable_connected(&mut self) {
+        self.0 &= 0b0111
+    }
+
+    /// disconnected don't use blocking
+    #[inline]
+    pub fn disable_disconnected(&mut self) {
+        self.0 &= 0b1011
+    }
+
+    /// received don't use blocking
+    #[inline]
+    pub fn disable_received(&mut self) {
+        self.0 &= 0b1101
+    }
+
+    /// notify don't use blocking
+    pub fn disable_notify(&mut self) {
+        self.0 &= 0b1110
+    }
+
+    /// all function use blocking
+    #[inline]
+    pub fn enable_all(&mut self) {
+        self.0 |= 0b1111
+    }
+
+    /// all function don't use blocking
+    #[inline]
+    pub fn disable_all(&mut self) {
+        self.0 &= 0b0000
+    }
+
+    /// return true if connected enable
+    #[inline]
+    pub const fn connected(self) -> bool {
+        self.0 & 0b1000 > 0
+    }
+
+    /// return true if disconnected enable
+    #[inline]
+    pub const fn disconnected(self) -> bool {
+        self.0 & 0b0100 > 0
+    }
+
+    /// return true if received enable
+    #[inline]
+    pub const fn received(self) -> bool {
+        self.0 & 0b0010 > 0
+    }
+
+    /// return true if notify enable
+    #[inline]
+    pub const fn notify(self) -> bool {
+        self.0 & 0b0001 > 0
+    }
+}
+
+impl Default for BlockingFlag {
+    fn default() -> Self {
+        BlockingFlag(0b1111)
+    }
+}
+
 /// Service state
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum State {
@@ -318,7 +401,7 @@ impl State {
 
 #[cfg(test)]
 mod test {
-    use super::State;
+    use super::{BlockingFlag, State};
 
     #[test]
     fn test_state_no_forever() {
@@ -352,5 +435,31 @@ mod test {
         state.increase();
         state.pre_shutdown();
         assert_eq!(state, State::PreShutdown);
+    }
+
+    #[test]
+    fn test_proto_flag() {
+        let mut p = BlockingFlag::default();
+
+        assert_eq!(p.connected(), true);
+        assert_eq!(p.disconnected(), true);
+        assert_eq!(p.received(), true);
+        assert_eq!(p.notify(), true);
+
+        p.disable_connected();
+        assert_eq!(p.connected(), false);
+        p.disable_disconnected();
+        assert_eq!(p.disconnected(), false);
+        p.disable_received();
+        assert_eq!(p.received(), false);
+        p.disable_notify();
+        assert_eq!(p.notify(), false);
+
+        p.enable_all();
+        p.disable_all();
+        assert_eq!(p.connected(), false);
+        assert_eq!(p.disconnected(), false);
+        assert_eq!(p.received(), false);
+        assert_eq!(p.notify(), false);
     }
 }


### PR DESCRIPTION
Previously, `block_in_place` was used by default to perform user behavior, just for convenience, but in practice, most functions do not require this operation, now a flag is added to let the user control this behavior.

There is a lot of `block_in_place` behaviors, such as judging and setting status, opening new threads, etc. These are additional overheads, and if the user can control whether this behavior is needed or not, it is a big improvement to overall performance.

I used a simple demo to test the difference between the two:

```rust
use criterion::{criterion_group, criterion_main, Bencher, Criterion};
use std::collections::HashMap;

fn blocking(rt: &mut tokio::runtime::Runtime, hash_time: usize) {
    rt.block_on(async move {
        let mut handles = Vec::new();
        for _ in 0..256 {
            let handle = tokio::spawn(async move {
                tokio::task::block_in_place(move || {
                    let a = 1 + 1;
                    let b: HashMap<usize, usize> = HashMap::new();
                    for _ in 0..hash_time {
                        b.contains_key(&a);
                    }
                })
            });
            handles.push(handle);
        }
        for handle in handles {
            handle.await;
        }
    })
}

fn no_block(rt: &mut tokio::runtime::Runtime, hash_time: usize) {
    rt.block_on(async move {
        let mut handles = Vec::new();
        for _ in 0..256 {
            let _ = 8u8 & 20u8;
            let handle = tokio::spawn(async move {
                let a = 1 + 1;
                let b: HashMap<usize, usize> = HashMap::new();
                for _ in 0..hash_time {
                    b.contains_key(&a);
                }
            });
            handles.push(handle);
        }
        for handle in handles {
            handle.await;
        }
    })
}

fn test_block(
    bench: &mut Bencher,
    rt: &mut tokio::runtime::Runtime,
    block: bool,
    hash_time: usize,
) {
    bench.iter(|| {
        if block {
            blocking(rt, hash_time)
        } else {
            no_block(rt, hash_time)
        }
    })
}

fn criterion_benchmark(bench: &mut Criterion) {
    let mut rt = tokio::runtime::Runtime::new().unwrap();
    bench.bench_function("blocking and hash 1 time", {
        |b| test_block(b, &mut rt, true, 1)
    });
    bench.bench_function("no blocking and hash 1 time", {
        |b| test_block(b, &mut rt, false, 1)
    });

    bench.bench_function("blocking and hash 1000 time", {
        |b| test_block(b, &mut rt, true, 1000)
    });
    bench.bench_function("no blocking and hash 1000 time", {
        |b| test_block(b, &mut rt, false, 1000)
    });

    bench.bench_function("blocking and hash 10000 time", {
        |b| test_block(b, &mut rt, true, 10000)
    });
    bench.bench_function("no blocking and hash 10000 time", {
        |b| test_block(b, &mut rt, false, 10000)
    });
}

criterion_group!(benches, criterion_benchmark);
criterion_main!(benches);
```

result:

```
blocking and hash 1 time time:   [1.2777 ms 1.2941 ms 1.3143 ms]

no blocking and hash 1 time                                                                            
                        time:   [165.12 us 166.46 us 167.86 us]

blocking and hash 1000 time                                                                             
                        time:   [1.5778 ms 1.6277 ms 1.6815 ms]

no blocking and hash 1000 time                                                                             
                        time:   [1.3526 ms 1.3867 ms 1.4255 ms]

blocking and hash 10000 time                                                                             
                        time:   [11.069 ms 11.164 ms 11.256 ms]

no blocking and hash 10000 time                                                                             
                        time:   [11.824 ms 11.939 ms 12.066 ms]
```
There's a fixed performance loss of nearly an order of magnitude in a simple scene. Of course, this can't be blamed on the implementation, as there really is a lot of checking and status switching required inside, but it would be a good idea if users could choose whether or not to use this function based on their own behavior