### PR TITLE
chore: update tokio-tungstenite to 1.05 & fix websocket compile

### DIFF
--- a/tentacle/Cargo.toml
+++ b/tentacle/Cargo.toml
@@ -31,7 +31,7 @@ once_cell = "1.0"
 nohash-hasher = "0.2"
 
 parking_lot = { version = "0.11", optional = true }
-tokio-tungstenite = { version = "0.13", optional = true }
+tokio-tungstenite = { version = "0.15", optional = true }
 futures-timer = { version = "3.0.2", optional = true }
 async-std = { version = "1", features = ["unstable"], optional = true }
 async-io = { version = "1", optional = true }

--- a/tentacle/examples/simple.rs
+++ b/tentacle/examples/simple.rs
@@ -215,6 +215,7 @@ fn server() {
             .listen("/ip4/127.0.0.1/tcp/1337".parse().unwrap())
             .await
             .unwrap();
+        #[cfg(feature = "ws")]
         service
             .listen("/ip4/127.0.0.1/tcp/1338/ws".parse().unwrap())
             .await

--- a/tentacle/examples/simple_using_spawn.rs
+++ b/tentacle/examples/simple_using_spawn.rs
@@ -157,6 +157,7 @@ fn server() {
             .listen("/ip4/127.0.0.1/tcp/1337".parse().unwrap())
             .await
             .unwrap();
+        #[cfg(feature = "ws")]
         service
             .listen("/ip4/127.0.0.1/tcp/1338/ws".parse().unwrap())
             .await


### PR DESCRIPTION
chore: update tokio-tungstenite to 1.05 & fix websocket compile in examples