### PR TITLE
Add new struct `ServiceConfig{timeout, onion_timeout}` to `ServiceConfig`

### DIFF
--- a/tentacle/src/builder.rs
+++ b/tentacle/src/builder.rs
@@ -1,6 +1,6 @@
 use std::{io, sync::Arc, time::Duration};
 
-use crate::service::config::{ServiceTimeout, TransformerContext};
+use crate::service::config::TransformerContext;
 use nohash_hasher::IntMap;
 use tokio_util::codec::LengthDelimitedCodec;
 
@@ -83,12 +83,17 @@ where
 
     /// Timeout for handshake and connect
     ///
-    /// Default timeout is 10 second, default onion_timeout is 120 second
-    pub fn timeout(mut self, timeout: Duration, onion_timeout: Duration) -> Self {
-        self.config.timeout = ServiceTimeout {
-            timeout,
-            onion_timeout,
-        };
+    /// Default timeout is 10 second
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.config.timeout.timeout = timeout;
+        self
+    }
+
+    /// Onion Timeout for handshake and connect
+    ///
+    /// Default onion_timeout is 120 second
+    pub fn onion_timeout(mut self, onion_timeout: Duration) -> Self {
+        self.config.timeout.onion_timeout = onion_timeout;
         self
     }
 

--- a/tentacle/src/service.rs
+++ b/tentacle/src/service.rs
@@ -170,7 +170,7 @@ where
                 handshake_type,
                 multi_transport: {
                     #[cfg(target_family = "wasm")]
-                    let transport = MultiTransport::new(config.timeout);
+                    let transport = MultiTransport::new(config.timeout.timeout);
                     #[allow(clippy::let_and_return)]
                     #[cfg(not(target_family = "wasm"))]
                     let transport = MultiTransport::new(config.timeout, config.tcp_config.clone());
@@ -309,7 +309,7 @@ where
             handshake_type: self.handshake_type.clone(),
             event_sender: self.session_event_sender.clone(),
             max_frame_length: self.config.max_frame_length,
-            timeout: self.config.timeout,
+            timeout: self.config.timeout.timeout,
             listen_addr: listen_address,
             future_task_sender: self.future_task_sender.clone(),
         };
@@ -362,7 +362,7 @@ where
         self.dial_protocols.insert(address.clone(), target);
 
         let handshake_type = self.handshake_type.clone();
-        let timeout = self.config.timeout;
+        let timeout = self.config.timeout.timeout;
         let max_frame_length = self.config.max_frame_length;
 
         let mut sender = self.session_event_sender.clone();
@@ -542,7 +542,7 @@ where
             handshake_type: self.handshake_type.clone(),
             event_sender: self.session_event_sender.clone(),
             max_frame_length: self.config.max_frame_length,
-            timeout: self.config.timeout,
+            timeout: self.config.timeout.timeout,
         }
         .handshake(socket);
 
@@ -681,7 +681,7 @@ where
         });
 
         let meta = SessionMeta::new(
-            self.config.timeout,
+            self.config.timeout.timeout,
             session_context.clone(),
             service_event_sender,
             self.service_context.control().clone(),

--- a/tentacle/src/service/config.rs
+++ b/tentacle/src/service/config.rs
@@ -20,9 +20,10 @@ use tokio_rustls::rustls::{ClientConfig, ServerConfig};
 /// Default max buffer size
 const MAX_BUF_SIZE: usize = 24 * 1024 * 1024;
 
+#[derive(Clone, Copy)]
 pub(crate) struct ServiceTimeout {
-    timeout: Duration,
-    onion_timeout: Duration,
+    pub timeout: Duration,
+    pub onion_timeout: Duration,
 }
 
 impl Default for ServiceTimeout {

--- a/tentacle/src/transports/tcp.rs
+++ b/tentacle/src/transports/tcp.rs
@@ -62,7 +62,7 @@ impl TcpTransport {
         listen_mode: TcpListenMode,
     ) -> Self {
         Self {
-            timeout: multi_transport.timeout,
+            timeout: multi_transport.timeout.timeout,
             tcp_config: match listen_mode {
                 TcpListenMode::Tcp => multi_transport.tcp_config.tcp,
                 #[cfg(feature = "ws")]


### PR DESCRIPTION
Connecting to an onion target takes longer than connecting to a non-onion target, so set the default onion timeout to 120 seconds.
