### PR TITLE
quic: support quic/udp address parsing

### DIFF
--- a/multiaddr/src/error.rs
+++ b/multiaddr/src/error.rs
@@ -7,6 +7,7 @@ pub enum Error {
     InvalidMultiaddr,
     InvalidOnion3Addr,
     InvalidProtocolString,
+    InvalidPort,
     InvalidUvar(decode::Error),
     ParsingError(Box<dyn error::Error + Send + Sync>),
     UnknownHash,
@@ -26,6 +27,7 @@ impl fmt::Display for Error {
             Error::UnknownHash => write!(f, "unknown hash"),
             Error::UnknownProtocolId(id) => write!(f, "unknown protocol id: {}", id),
             Error::UnknownProtocolString => f.write_str("unknown protocol string"),
+            Error::InvalidPort => f.write_str("Invalid port")
         }
     }
 }

--- a/multiaddr/src/error.rs
+++ b/multiaddr/src/error.rs
@@ -7,7 +7,6 @@ pub enum Error {
     InvalidMultiaddr,
     InvalidOnion3Addr,
     InvalidProtocolString,
-    InvalidPort,
     InvalidUvar(decode::Error),
     ParsingError(Box<dyn error::Error + Send + Sync>),
     UnknownHash,
@@ -27,7 +26,6 @@ impl fmt::Display for Error {
             Error::UnknownHash => write!(f, "unknown hash"),
             Error::UnknownProtocolId(id) => write!(f, "unknown protocol id: {}", id),
             Error::UnknownProtocolString => f.write_str("unknown protocol string"),
-            Error::InvalidPort => f.write_str("Invalid port"),
         }
     }
 }

--- a/multiaddr/src/error.rs
+++ b/multiaddr/src/error.rs
@@ -27,7 +27,7 @@ impl fmt::Display for Error {
             Error::UnknownHash => write!(f, "unknown hash"),
             Error::UnknownProtocolId(id) => write!(f, "unknown protocol id: {}", id),
             Error::UnknownProtocolString => f.write_str("unknown protocol string"),
-            Error::InvalidPort => f.write_str("Invalid port")
+            Error::InvalidPort => f.write_str("Invalid port"),
         }
     }
 }

--- a/multiaddr/src/lib.rs
+++ b/multiaddr/src/lib.rs
@@ -424,36 +424,3 @@ macro_rules! multiaddr {
         }
     }
 }
-
-#[cfg(test)]
-mod test {
-    use super::{Multiaddr, Protocol};
-    use parity_multiaddr::{Multiaddr as OtherMultiaddr, Protocol as OtherProtocol};
-
-    #[test]
-    fn compatibility_test() {
-        let mut address: Multiaddr = "/ip4/127.0.0.1".parse().unwrap();
-        address.push(Protocol::Tcp(10000));
-        assert_eq!(address, "/ip4/127.0.0.1/tcp/10000".parse().unwrap());
-
-        let _address: Multiaddr = "/ip4/127.0.0.1/tcp/20/tls/main".parse().unwrap();
-
-        let mut address_1: Multiaddr =
-            "/ip4/47.111.169.36/tcp/8111/p2p/QmNQ4jky6uVqLDrPU7snqxARuNGWNLgSrTnssbRuy3ij2W"
-                .parse()
-                .unwrap();
-
-        let mut address_2: OtherMultiaddr =
-            "/ip4/47.111.169.36/tcp/8111/p2p/QmNQ4jky6uVqLDrPU7snqxARuNGWNLgSrTnssbRuy3ij2W"
-                .parse()
-                .unwrap();
-
-        let p_1 = address_1.pop().unwrap();
-        let p_2 = address_2.pop().unwrap();
-
-        match (p_1, p_2) {
-            (Protocol::P2P(s_1), OtherProtocol::P2p(s_2)) => assert_eq!(s_1, s_2.to_bytes()),
-            e => panic!("not expect protocol: {:?}", e),
-        }
-    }
-}

--- a/multiaddr/src/protocol.rs
+++ b/multiaddr/src/protocol.rs
@@ -23,6 +23,8 @@ const WS: u32 = 0x01dd;
 const WSS: u32 = 0x01de;
 const MEMORY: u32 = 0x0309;
 const ONION3: u32 = 0x01bd;
+const QUIC: u32 = 0x1111;
+const UDP: u32 = 0x01cc;
 
 const SHA256_CODE: u64 = 0x12;
 const SHA256_SIZE: u8 = 32;
@@ -42,6 +44,8 @@ pub enum Protocol<'a> {
     /// Contains the "port" to contact. Similar to TCP or UDP, 0 means "assign me a port".
     Memory(u64),
     Onion3(Onion3Addr<'a>),
+    Udp(u16),
+    Quic,
 }
 
 impl<'a> Protocol<'a> {
@@ -97,6 +101,13 @@ impl<'a> Protocol<'a> {
                 .ok_or(Error::InvalidProtocolString)
                 .and_then(|s| read_onion3(&s.to_uppercase()))
                 .map(|(a, p)| Protocol::Onion3((a, p).into())),
+            "udp" => {
+                let s = iter.next().ok_or(Error::InvalidProtocolString)?;
+                Ok(Protocol::Udp(
+                    u16::from_str_radix(s, 10).map_err(|_| Error::InvalidPort)?,
+                ))
+            }
+            "quic" => Ok(Protocol::Quic),
             _ => Err(Error::UnknownProtocolString),
         }
     }
@@ -179,6 +190,12 @@ impl<'a> Protocol<'a> {
                     rest,
                 ))
             }
+            UDP => {
+                let (data, rest) = split_header(2, input)?;
+                let port = BigEndian::read_u16(&data[..]);
+                Ok((Protocol::Udp(port), rest))
+            }
+            QUIC => Ok((Protocol::Quic, input)),
             _ => Err(Error::UnknownProtocolId(id)),
         }
     }
@@ -237,6 +254,11 @@ impl<'a> Protocol<'a> {
                 w.put(addr.hash().as_ref());
                 w.put_u16(addr.port());
             }
+            Protocol::Udp(port) => {
+                w.put(encode::u32(UDP, &mut buf));
+                w.put_u16(*port);
+            }
+            Protocol::Quic => w.put(encode::u32(QUIC, &mut buf)),
         }
     }
 
@@ -254,6 +276,8 @@ impl<'a> Protocol<'a> {
             Protocol::Wss => Protocol::Wss,
             Protocol::Memory(a) => Protocol::Memory(a),
             Protocol::Onion3(addr) => Protocol::Onion3(addr.acquire()),
+            Protocol::Udp(port) => Protocol::Udp(port),
+            Protocol::Quic => Protocol::Quic,
         }
     }
 }
@@ -275,6 +299,8 @@ impl fmt::Display for Protocol<'_> {
             Onion3(addr) => {
                 write!(f, "/onion3/{}:{}", addr.hash_string(), addr.port())
             }
+            Udp(port) => write!(f, "/udp/{}", port),
+            Quic => write!(f, "/quic"),
         }
     }
 }

--- a/multiaddr/src/protocol.rs
+++ b/multiaddr/src/protocol.rs
@@ -23,8 +23,8 @@ const WS: u32 = 0x01dd;
 const WSS: u32 = 0x01de;
 const MEMORY: u32 = 0x0309;
 const ONION3: u32 = 0x01bd;
-const QUIC: u32 = 0x1111;
-const UDP: u32 = 0x01cc;
+const QUICV1: u32 = 0x01cd;
+const UDP: u32 = 0x0111;
 
 const SHA256_CODE: u64 = 0x12;
 const SHA256_SIZE: u8 = 32;
@@ -45,7 +45,7 @@ pub enum Protocol<'a> {
     Memory(u64),
     Onion3(Onion3Addr<'a>),
     Udp(u16),
-    Quic,
+    QuicV1,
 }
 
 impl<'a> Protocol<'a> {
@@ -103,11 +103,9 @@ impl<'a> Protocol<'a> {
                 .map(|(a, p)| Protocol::Onion3((a, p).into())),
             "udp" => {
                 let s = iter.next().ok_or(Error::InvalidProtocolString)?;
-                Ok(Protocol::Udp(
-                    u16::from_str_radix(s, 10).map_err(|_| Error::InvalidPort)?,
-                ))
+                Ok(Protocol::Udp(s.parse()?))
             }
-            "quic" => Ok(Protocol::Quic),
+            "quic-v1" => Ok(Protocol::QuicV1),
             _ => Err(Error::UnknownProtocolString),
         }
     }
@@ -195,7 +193,7 @@ impl<'a> Protocol<'a> {
                 let port = BigEndian::read_u16(&data[..]);
                 Ok((Protocol::Udp(port), rest))
             }
-            QUIC => Ok((Protocol::Quic, input)),
+            QUICV1 => Ok((Protocol::QuicV1, input)),
             _ => Err(Error::UnknownProtocolId(id)),
         }
     }
@@ -258,7 +256,7 @@ impl<'a> Protocol<'a> {
                 w.put(encode::u32(UDP, &mut buf));
                 w.put_u16(*port);
             }
-            Protocol::Quic => w.put(encode::u32(QUIC, &mut buf)),
+            Protocol::QuicV1 => w.put(encode::u32(QUICV1, &mut buf)),
         }
     }
 
@@ -277,7 +275,7 @@ impl<'a> Protocol<'a> {
             Protocol::Memory(a) => Protocol::Memory(a),
             Protocol::Onion3(addr) => Protocol::Onion3(addr.acquire()),
             Protocol::Udp(port) => Protocol::Udp(port),
-            Protocol::Quic => Protocol::Quic,
+            Protocol::QuicV1 => Protocol::QuicV1,
         }
     }
 }
@@ -300,7 +298,7 @@ impl fmt::Display for Protocol<'_> {
                 write!(f, "/onion3/{}:{}", addr.hash_string(), addr.port())
             }
             Udp(port) => write!(f, "/udp/{}", port),
-            Quic => write!(f, "/quic"),
+            QuicV1 => write!(f, "/quic-v1"),
         }
     }
 }

--- a/multiaddr/tests/lib.rs
+++ b/multiaddr/tests/lib.rs
@@ -1,2 +1,31 @@
+use parity_multiaddr::{Multiaddr as OtherMultiaddr, Protocol as OtherProtocol};
+use tentacle_multiaddr::{Multiaddr, Protocol};
 mod onion;
 mod quic;
+
+#[test]
+fn compatibility_test() {
+    let mut address: Multiaddr = "/ip4/127.0.0.1".parse().unwrap();
+    address.push(Protocol::Tcp(10000));
+    assert_eq!(address, "/ip4/127.0.0.1/tcp/10000".parse().unwrap());
+
+    let _address: Multiaddr = "/ip4/127.0.0.1/tcp/20/tls/main".parse().unwrap();
+
+    let mut address_1: Multiaddr =
+        "/ip4/47.111.169.36/tcp/8111/p2p/QmNQ4jky6uVqLDrPU7snqxARuNGWNLgSrTnssbRuy3ij2W"
+            .parse()
+            .unwrap();
+
+    let mut address_2: OtherMultiaddr =
+        "/ip4/47.111.169.36/tcp/8111/p2p/QmNQ4jky6uVqLDrPU7snqxARuNGWNLgSrTnssbRuy3ij2W"
+            .parse()
+            .unwrap();
+
+    let p_1 = address_1.pop().unwrap();
+    let p_2 = address_2.pop().unwrap();
+
+    match (p_1, p_2) {
+        (Protocol::P2P(s_1), OtherProtocol::P2p(s_2)) => assert_eq!(s_1, s_2.to_bytes()),
+        e => panic!("not expect protocol: {:?}", e),
+    }
+}

--- a/multiaddr/tests/lib.rs
+++ b/multiaddr/tests/lib.rs
@@ -1,1 +1,2 @@
 mod onion;
+mod quic;

--- a/multiaddr/tests/quic.rs
+++ b/multiaddr/tests/quic.rs
@@ -1,0 +1,247 @@
+use data_encoding::HEXUPPER;
+use std::convert::TryFrom;
+use tentacle_multiaddr::{Multiaddr, Protocol};
+
+/// Helper: parse a multiaddr string, verify hex encoding roundtrip, protocol list, and Display roundtrip.
+fn ma_valid(source: &str, target: &str, protocols: Vec<Protocol<'_>>) {
+    let parsed = source.parse::<Multiaddr>().unwrap();
+    assert_eq!(HEXUPPER.encode(&parsed.to_vec()[..]), target);
+    assert_eq!(parsed.iter().collect::<Vec<_>>(), protocols);
+    assert_eq!(parsed.to_string(), source);
+    assert_eq!(
+        Multiaddr::try_from(HEXUPPER.decode(target.as_bytes()).unwrap()).unwrap(),
+        parsed
+    );
+}
+
+// ────────────────────────── String parse → Display roundtrip ──────────────────────────
+
+#[test]
+fn parse_ip4_udp_quic() {
+    let addr: Multiaddr = "/ip4/127.0.0.1/udp/4433/quic".parse().unwrap();
+    assert_eq!(addr.to_string(), "/ip4/127.0.0.1/udp/4433/quic");
+    assert_eq!(
+        addr.iter().collect::<Vec<_>>(),
+        vec![
+            Protocol::Ip4("127.0.0.1".parse().unwrap()),
+            Protocol::Udp(4433),
+            Protocol::Quic,
+        ]
+    );
+}
+
+#[test]
+fn parse_ip6_udp_quic() {
+    let addr: Multiaddr = "/ip6/::1/udp/4433/quic".parse().unwrap();
+    assert_eq!(addr.to_string(), "/ip6/::1/udp/4433/quic");
+    assert_eq!(
+        addr.iter().collect::<Vec<_>>(),
+        vec![
+            Protocol::Ip6("::1".parse().unwrap()),
+            Protocol::Udp(4433),
+            Protocol::Quic,
+        ]
+    );
+}
+
+#[test]
+fn parse_udp_port_zero() {
+    let addr: Multiaddr = "/ip4/0.0.0.0/udp/0/quic".parse().unwrap();
+    assert_eq!(addr.to_string(), "/ip4/0.0.0.0/udp/0/quic");
+    assert_eq!(
+        addr.iter().collect::<Vec<_>>(),
+        vec![
+            Protocol::Ip4("0.0.0.0".parse().unwrap()),
+            Protocol::Udp(0),
+            Protocol::Quic,
+        ]
+    );
+}
+
+#[test]
+fn parse_udp_port_max() {
+    let addr: Multiaddr = "/ip4/10.0.0.1/udp/65535/quic".parse().unwrap();
+    assert_eq!(
+        addr.iter().collect::<Vec<_>>(),
+        vec![
+            Protocol::Ip4("10.0.0.1".parse().unwrap()),
+            Protocol::Udp(65535),
+            Protocol::Quic,
+        ]
+    );
+}
+
+#[test]
+fn parse_udp_alone() {
+    // UDP without /quic is also a valid multiaddr
+    let addr: Multiaddr = "/ip4/127.0.0.1/udp/1234".parse().unwrap();
+    assert_eq!(addr.to_string(), "/ip4/127.0.0.1/udp/1234");
+    assert_eq!(
+        addr.iter().collect::<Vec<_>>(),
+        vec![
+            Protocol::Ip4("127.0.0.1".parse().unwrap()),
+            Protocol::Udp(1234),
+        ]
+    );
+}
+
+#[test]
+fn parse_quic_with_p2p_suffix() {
+    // A realistic QUIC address with /p2p/<peer_id> suffix
+    // Use a well-formed peer_id (sha256 multihash)
+    let peer_id_b58 = "QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC";
+    let source = format!("/ip4/192.168.1.1/udp/4433/quic/p2p/{}", peer_id_b58);
+    let addr: Multiaddr = source.parse().unwrap();
+    assert_eq!(addr.to_string(), source);
+
+    let protos: Vec<_> = addr.iter().collect();
+    assert_eq!(protos.len(), 4);
+    assert_eq!(protos[0], Protocol::Ip4("192.168.1.1".parse().unwrap()));
+    assert_eq!(protos[1], Protocol::Udp(4433));
+    assert_eq!(protos[2], Protocol::Quic);
+    match &protos[3] {
+        Protocol::P2P(_) => {} // ok
+        other => panic!("expected P2P, got {:?}", other),
+    }
+}
+
+// ────────────────────────── Binary (bytes) roundtrip ──────────────────────────
+
+#[test]
+fn bytes_roundtrip_ip4_udp_quic() {
+    let addr: Multiaddr = "/ip4/127.0.0.1/udp/4433/quic".parse().unwrap();
+    let bytes = addr.to_vec();
+    let decoded = Multiaddr::try_from(bytes).unwrap();
+    assert_eq!(decoded, addr);
+}
+
+#[test]
+fn bytes_roundtrip_ip6_udp_quic() {
+    let addr: Multiaddr = "/ip6/::1/udp/4433/quic".parse().unwrap();
+    let bytes = addr.to_vec();
+    let decoded = Multiaddr::try_from(bytes).unwrap();
+    assert_eq!(decoded, addr);
+}
+
+#[test]
+fn bytes_roundtrip_udp_alone() {
+    let addr: Multiaddr = "/ip4/10.0.0.1/udp/8080".parse().unwrap();
+    let bytes = addr.to_vec();
+    let decoded = Multiaddr::try_from(bytes).unwrap();
+    assert_eq!(decoded, addr);
+}
+
+// ────────────────────────── Hex encoding roundtrip (ma_valid style) ──────────────────────────
+
+#[test]
+fn hex_roundtrip_ip4_udp_quic() {
+    let addr: Multiaddr = "/ip4/127.0.0.1/udp/4433/quic".parse().unwrap();
+    let hex = HEXUPPER.encode(&addr.to_vec()[..]);
+
+    ma_valid(
+        "/ip4/127.0.0.1/udp/4433/quic",
+        &hex,
+        vec![
+            Protocol::Ip4("127.0.0.1".parse().unwrap()),
+            Protocol::Udp(4433),
+            Protocol::Quic,
+        ],
+    );
+}
+
+// ────────────────────────── Protocol push / pop ──────────────────────────
+
+#[test]
+fn push_pop_quic() {
+    let mut addr: Multiaddr = "/ip4/127.0.0.1/udp/4433".parse().unwrap();
+    addr.push(Protocol::Quic);
+    assert_eq!(addr.to_string(), "/ip4/127.0.0.1/udp/4433/quic");
+
+    let popped = addr.pop().unwrap();
+    assert_eq!(popped, Protocol::Quic);
+    assert_eq!(addr.to_string(), "/ip4/127.0.0.1/udp/4433");
+}
+
+#[test]
+fn push_pop_udp() {
+    let mut addr: Multiaddr = "/ip4/127.0.0.1".parse().unwrap();
+    addr.push(Protocol::Udp(9999));
+    assert_eq!(addr.to_string(), "/ip4/127.0.0.1/udp/9999");
+
+    let popped = addr.pop().unwrap();
+    assert_eq!(popped, Protocol::Udp(9999));
+    assert_eq!(addr.to_string(), "/ip4/127.0.0.1");
+}
+
+// ────────────────────────── acquire() (owned conversion) ──────────────────────────
+
+#[test]
+fn acquire_udp_quic() {
+    let addr: Multiaddr = "/ip4/10.0.0.1/udp/4433/quic".parse().unwrap();
+    let protos: Vec<Protocol<'static>> = addr.iter().map(|p| p.acquire()).collect();
+    assert_eq!(protos.len(), 3);
+    assert_eq!(protos[1], Protocol::Udp(4433));
+    assert_eq!(protos[2], Protocol::Quic);
+}
+
+// ────────────────────────── DNS + QUIC (parseable at multiaddr layer) ──────────────────────────
+// NOTE: DNS-based QUIC addresses are rejected by tentacle's transport layer (v1),
+// but multiaddr itself should parse them fine — it's a generic address format.
+
+#[test]
+fn parse_dns4_udp_quic_is_valid_multiaddr() {
+    let addr: Multiaddr = "/dns4/example.com/udp/4433/quic".parse().unwrap();
+    assert_eq!(addr.to_string(), "/dns4/example.com/udp/4433/quic");
+    assert_eq!(
+        addr.iter().collect::<Vec<_>>(),
+        vec![
+            Protocol::Dns4("example.com".into()),
+            Protocol::Udp(4433),
+            Protocol::Quic,
+        ]
+    );
+}
+
+#[test]
+fn parse_dns6_udp_quic_is_valid_multiaddr() {
+    let addr: Multiaddr = "/dns6/example.com/udp/4433/quic".parse().unwrap();
+    assert_eq!(addr.to_string(), "/dns6/example.com/udp/4433/quic");
+    assert_eq!(
+        addr.iter().collect::<Vec<_>>(),
+        vec![
+            Protocol::Dns6("example.com".into()),
+            Protocol::Udp(4433),
+            Protocol::Quic,
+        ]
+    );
+}
+
+// ────────────────────────── Error cases ──────────────────────────
+
+#[test]
+fn fail_udp_missing_port() {
+    // "/udp" without a port number
+    assert!("/udp".parse::<Multiaddr>().is_err());
+}
+
+#[test]
+fn fail_udp_non_numeric_port() {
+    assert!("/udp/abc".parse::<Multiaddr>().is_err());
+}
+
+#[test]
+fn fail_udp_port_overflow() {
+    // 65536 > u16::MAX
+    assert!("/ip4/127.0.0.1/udp/65536".parse::<Multiaddr>().is_err());
+}
+
+#[test]
+fn fail_udp_negative_port() {
+    assert!("/ip4/127.0.0.1/udp/-1".parse::<Multiaddr>().is_err());
+}
+
+#[test]
+fn fail_unknown_protocol() {
+    // Make sure adding udp/quic didn't break unknown protocol detection
+    assert!("/ip4/127.0.0.1/foobar/123".parse::<Multiaddr>().is_err());
+}

--- a/multiaddr/tests/quic.rs
+++ b/multiaddr/tests/quic.rs
@@ -1,4 +1,5 @@
 use data_encoding::HEXUPPER;
+use parity_multiaddr::{Multiaddr as OtherMultiaddr, Protocol as OtherProtocol};
 use std::convert::TryFrom;
 use tentacle_multiaddr::{Multiaddr, Protocol};
 
@@ -18,62 +19,62 @@ fn ma_valid(source: &str, target: &str, protocols: Vec<Protocol<'_>>) {
 
 #[test]
 fn parse_ip4_udp_quic() {
-    let addr: Multiaddr = "/ip4/127.0.0.1/udp/4433/quic".parse().unwrap();
-    assert_eq!(addr.to_string(), "/ip4/127.0.0.1/udp/4433/quic");
+    let addr: Multiaddr = "/ip4/127.0.0.1/udp/4433/quic-v1".parse().unwrap();
+    assert_eq!(addr.to_string(), "/ip4/127.0.0.1/udp/4433/quic-v1");
     assert_eq!(
         addr.iter().collect::<Vec<_>>(),
         vec![
             Protocol::Ip4("127.0.0.1".parse().unwrap()),
             Protocol::Udp(4433),
-            Protocol::Quic,
+            Protocol::QuicV1,
         ]
     );
 }
 
 #[test]
 fn parse_ip6_udp_quic() {
-    let addr: Multiaddr = "/ip6/::1/udp/4433/quic".parse().unwrap();
-    assert_eq!(addr.to_string(), "/ip6/::1/udp/4433/quic");
+    let addr: Multiaddr = "/ip6/::1/udp/4433/quic-v1".parse().unwrap();
+    assert_eq!(addr.to_string(), "/ip6/::1/udp/4433/quic-v1");
     assert_eq!(
         addr.iter().collect::<Vec<_>>(),
         vec![
             Protocol::Ip6("::1".parse().unwrap()),
             Protocol::Udp(4433),
-            Protocol::Quic,
+            Protocol::QuicV1,
         ]
     );
 }
 
 #[test]
 fn parse_udp_port_zero() {
-    let addr: Multiaddr = "/ip4/0.0.0.0/udp/0/quic".parse().unwrap();
-    assert_eq!(addr.to_string(), "/ip4/0.0.0.0/udp/0/quic");
+    let addr: Multiaddr = "/ip4/0.0.0.0/udp/0/quic-v1".parse().unwrap();
+    assert_eq!(addr.to_string(), "/ip4/0.0.0.0/udp/0/quic-v1");
     assert_eq!(
         addr.iter().collect::<Vec<_>>(),
         vec![
             Protocol::Ip4("0.0.0.0".parse().unwrap()),
             Protocol::Udp(0),
-            Protocol::Quic,
+            Protocol::QuicV1,
         ]
     );
 }
 
 #[test]
 fn parse_udp_port_max() {
-    let addr: Multiaddr = "/ip4/10.0.0.1/udp/65535/quic".parse().unwrap();
+    let addr: Multiaddr = "/ip4/10.0.0.1/udp/65535/quic-v1".parse().unwrap();
     assert_eq!(
         addr.iter().collect::<Vec<_>>(),
         vec![
             Protocol::Ip4("10.0.0.1".parse().unwrap()),
             Protocol::Udp(65535),
-            Protocol::Quic,
+            Protocol::QuicV1,
         ]
     );
 }
 
 #[test]
 fn parse_udp_alone() {
-    // UDP without /quic is also a valid multiaddr
+    // UDP without /quic-v1 is also a valid multiaddr
     let addr: Multiaddr = "/ip4/127.0.0.1/udp/1234".parse().unwrap();
     assert_eq!(addr.to_string(), "/ip4/127.0.0.1/udp/1234");
     assert_eq!(
@@ -90,7 +91,7 @@ fn parse_quic_with_p2p_suffix() {
     // A realistic QUIC address with /p2p/<peer_id> suffix
     // Use a well-formed peer_id (sha256 multihash)
     let peer_id_b58 = "QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC";
-    let source = format!("/ip4/192.168.1.1/udp/4433/quic/p2p/{}", peer_id_b58);
+    let source = format!("/ip4/192.168.1.1/udp/4433/quic-v1/p2p/{}", peer_id_b58);
     let addr: Multiaddr = source.parse().unwrap();
     assert_eq!(addr.to_string(), source);
 
@@ -98,7 +99,7 @@ fn parse_quic_with_p2p_suffix() {
     assert_eq!(protos.len(), 4);
     assert_eq!(protos[0], Protocol::Ip4("192.168.1.1".parse().unwrap()));
     assert_eq!(protos[1], Protocol::Udp(4433));
-    assert_eq!(protos[2], Protocol::Quic);
+    assert_eq!(protos[2], Protocol::QuicV1);
     match &protos[3] {
         Protocol::P2P(_) => {} // ok
         other => panic!("expected P2P, got {:?}", other),
@@ -109,7 +110,7 @@ fn parse_quic_with_p2p_suffix() {
 
 #[test]
 fn bytes_roundtrip_ip4_udp_quic() {
-    let addr: Multiaddr = "/ip4/127.0.0.1/udp/4433/quic".parse().unwrap();
+    let addr: Multiaddr = "/ip4/127.0.0.1/udp/4433/quic-v1".parse().unwrap();
     let bytes = addr.to_vec();
     let decoded = Multiaddr::try_from(bytes).unwrap();
     assert_eq!(decoded, addr);
@@ -117,7 +118,7 @@ fn bytes_roundtrip_ip4_udp_quic() {
 
 #[test]
 fn bytes_roundtrip_ip6_udp_quic() {
-    let addr: Multiaddr = "/ip6/::1/udp/4433/quic".parse().unwrap();
+    let addr: Multiaddr = "/ip6/::1/udp/4433/quic-v1".parse().unwrap();
     let bytes = addr.to_vec();
     let decoded = Multiaddr::try_from(bytes).unwrap();
     assert_eq!(decoded, addr);
@@ -135,16 +136,16 @@ fn bytes_roundtrip_udp_alone() {
 
 #[test]
 fn hex_roundtrip_ip4_udp_quic() {
-    let addr: Multiaddr = "/ip4/127.0.0.1/udp/4433/quic".parse().unwrap();
+    let addr: Multiaddr = "/ip4/127.0.0.1/udp/4433/quic-v1".parse().unwrap();
     let hex = HEXUPPER.encode(&addr.to_vec()[..]);
 
     ma_valid(
-        "/ip4/127.0.0.1/udp/4433/quic",
+        "/ip4/127.0.0.1/udp/4433/quic-v1",
         &hex,
         vec![
             Protocol::Ip4("127.0.0.1".parse().unwrap()),
             Protocol::Udp(4433),
-            Protocol::Quic,
+            Protocol::QuicV1,
         ],
     );
 }
@@ -154,11 +155,11 @@ fn hex_roundtrip_ip4_udp_quic() {
 #[test]
 fn push_pop_quic() {
     let mut addr: Multiaddr = "/ip4/127.0.0.1/udp/4433".parse().unwrap();
-    addr.push(Protocol::Quic);
-    assert_eq!(addr.to_string(), "/ip4/127.0.0.1/udp/4433/quic");
+    addr.push(Protocol::QuicV1);
+    assert_eq!(addr.to_string(), "/ip4/127.0.0.1/udp/4433/quic-v1");
 
     let popped = addr.pop().unwrap();
-    assert_eq!(popped, Protocol::Quic);
+    assert_eq!(popped, Protocol::QuicV1);
     assert_eq!(addr.to_string(), "/ip4/127.0.0.1/udp/4433");
 }
 
@@ -177,11 +178,11 @@ fn push_pop_udp() {
 
 #[test]
 fn acquire_udp_quic() {
-    let addr: Multiaddr = "/ip4/10.0.0.1/udp/4433/quic".parse().unwrap();
+    let addr: Multiaddr = "/ip4/10.0.0.1/udp/4433/quic-v1".parse().unwrap();
     let protos: Vec<Protocol<'static>> = addr.iter().map(|p| p.acquire()).collect();
     assert_eq!(protos.len(), 3);
     assert_eq!(protos[1], Protocol::Udp(4433));
-    assert_eq!(protos[2], Protocol::Quic);
+    assert_eq!(protos[2], Protocol::QuicV1);
 }
 
 // ────────────────────────── DNS + QUIC (parseable at multiaddr layer) ──────────────────────────
@@ -190,28 +191,28 @@ fn acquire_udp_quic() {
 
 #[test]
 fn parse_dns4_udp_quic_is_valid_multiaddr() {
-    let addr: Multiaddr = "/dns4/example.com/udp/4433/quic".parse().unwrap();
-    assert_eq!(addr.to_string(), "/dns4/example.com/udp/4433/quic");
+    let addr: Multiaddr = "/dns4/example.com/udp/4433/quic-v1".parse().unwrap();
+    assert_eq!(addr.to_string(), "/dns4/example.com/udp/4433/quic-v1");
     assert_eq!(
         addr.iter().collect::<Vec<_>>(),
         vec![
             Protocol::Dns4("example.com".into()),
             Protocol::Udp(4433),
-            Protocol::Quic,
+            Protocol::QuicV1,
         ]
     );
 }
 
 #[test]
 fn parse_dns6_udp_quic_is_valid_multiaddr() {
-    let addr: Multiaddr = "/dns6/example.com/udp/4433/quic".parse().unwrap();
-    assert_eq!(addr.to_string(), "/dns6/example.com/udp/4433/quic");
+    let addr: Multiaddr = "/dns6/example.com/udp/4433/quic-v1".parse().unwrap();
+    assert_eq!(addr.to_string(), "/dns6/example.com/udp/4433/quic-v1");
     assert_eq!(
         addr.iter().collect::<Vec<_>>(),
         vec![
             Protocol::Dns6("example.com".into()),
             Protocol::Udp(4433),
-            Protocol::Quic,
+            Protocol::QuicV1,
         ]
     );
 }
@@ -242,6 +243,242 @@ fn fail_udp_negative_port() {
 
 #[test]
 fn fail_unknown_protocol() {
-    // Make sure adding udp/quic didn't break unknown protocol detection
+    // Make sure adding udp/quic-v1 didn't break unknown protocol detection
     assert!("/ip4/127.0.0.1/foobar/123".parse::<Multiaddr>().is_err());
+}
+
+// ────────────────────────── Cross-crate compatibility (tentacle vs parity) ──────────────────────────
+
+#[test]
+fn compat_udp_parse_string() {
+    // Both crates should parse the same /ip4/.../udp/... string identically
+    let source = "/ip4/127.0.0.1/udp/4433";
+    let addr_t: Multiaddr = source.parse().unwrap();
+    let addr_p: OtherMultiaddr = source.parse().unwrap();
+
+    assert_eq!(addr_t.to_string(), addr_p.to_string());
+}
+
+#[test]
+fn compat_udp_binary_encoding() {
+    // UDP wire encoding should be identical between tentacle and parity
+    let source = "/ip4/127.0.0.1/udp/4433";
+    let addr_t: Multiaddr = source.parse().unwrap();
+    let addr_p: OtherMultiaddr = source.parse().unwrap();
+
+    assert_eq!(addr_t.to_vec(), addr_p.to_vec());
+}
+
+#[test]
+fn compat_udp_binary_cross_decode() {
+    // Bytes produced by one crate should be decodable by the other
+    let source = "/ip4/10.0.0.1/udp/8080";
+
+    let addr_t: Multiaddr = source.parse().unwrap();
+    let bytes_t = addr_t.to_vec();
+    let decoded_p = OtherMultiaddr::try_from(bytes_t).unwrap();
+    assert_eq!(decoded_p.to_string(), source);
+
+    let addr_p: OtherMultiaddr = source.parse().unwrap();
+    let bytes_p = addr_p.to_vec();
+    let decoded_t = Multiaddr::try_from(bytes_p).unwrap();
+    assert_eq!(decoded_t.to_string(), source);
+}
+
+#[test]
+fn compat_udp_protocol_iter() {
+    // Both crates should iterate to the same protocol components for UDP
+    let source = "/ip4/192.168.1.1/udp/9999";
+    let addr_t: Multiaddr = source.parse().unwrap();
+    let addr_p: OtherMultiaddr = source.parse().unwrap();
+
+    let protos_t: Vec<_> = addr_t.iter().collect();
+    let protos_p: Vec<_> = addr_p.iter().collect();
+
+    assert_eq!(protos_t.len(), protos_p.len());
+
+    // Compare Ip4
+    match (&protos_t[0], &protos_p[0]) {
+        (Protocol::Ip4(a), OtherProtocol::Ip4(b)) => assert_eq!(a, b),
+        e => panic!("expected Ip4, got {:?}", e),
+    }
+
+    // Compare Udp
+    match (&protos_t[1], &protos_p[1]) {
+        (Protocol::Udp(a), OtherProtocol::Udp(b)) => assert_eq!(a, b),
+        e => panic!("expected Udp, got {:?}", e),
+    }
+}
+
+#[test]
+fn compat_udp_push_pop() {
+    // Push UDP on both crates, verify same result, then pop and compare
+    let base = "/ip4/127.0.0.1";
+    let mut addr_t: Multiaddr = base.parse().unwrap();
+    let mut addr_p: OtherMultiaddr = base.parse().unwrap();
+
+    addr_t.push(Protocol::Udp(5555));
+    addr_p.push(OtherProtocol::Udp(5555));
+
+    assert_eq!(addr_t.to_string(), addr_p.to_string());
+    assert_eq!(addr_t.to_vec(), addr_p.to_vec());
+
+    let popped_t = addr_t.pop().unwrap();
+    let popped_p = addr_p.pop().unwrap();
+
+    match (popped_t, popped_p) {
+        (Protocol::Udp(a), OtherProtocol::Udp(b)) => assert_eq!(a, b),
+        e => panic!("expected Udp, got {:?}", e),
+    }
+
+    assert_eq!(addr_t.to_string(), addr_p.to_string());
+}
+
+#[test]
+fn compat_udp_port_boundaries() {
+    // Verify port 0 and port 65535 produce identical encodings
+    for port in [0u16, 1, 1234, 65535] {
+        let source = format!("/ip4/0.0.0.0/udp/{}", port);
+        let addr_t: Multiaddr = source.parse().unwrap();
+        let addr_p: OtherMultiaddr = source.parse().unwrap();
+
+        assert_eq!(addr_t.to_string(), addr_p.to_string());
+        assert_eq!(addr_t.to_vec(), addr_p.to_vec());
+    }
+}
+
+#[test]
+fn compat_ip6_udp_binary() {
+    // IPv6 + UDP should also produce identical binary encodings
+    let source = "/ip6/::1/udp/4433";
+    let addr_t: Multiaddr = source.parse().unwrap();
+    let addr_p: OtherMultiaddr = source.parse().unwrap();
+
+    assert_eq!(addr_t.to_string(), addr_p.to_string());
+    assert_eq!(addr_t.to_vec(), addr_p.to_vec());
+}
+
+#[test]
+fn compat_ip6_udp_cross_decode() {
+    let source = "/ip6/fe80::1/udp/8443";
+
+    let addr_t: Multiaddr = source.parse().unwrap();
+    let decoded_p = OtherMultiaddr::try_from(addr_t.to_vec()).unwrap();
+    assert_eq!(decoded_p.to_string(), source);
+
+    let addr_p: OtherMultiaddr = source.parse().unwrap();
+    let decoded_t = Multiaddr::try_from(addr_p.to_vec()).unwrap();
+    assert_eq!(decoded_t.to_string(), source);
+}
+
+#[test]
+fn compat_quicv1_shared_prefix_binary() {
+    // parity-multiaddr 0.11 does not have QuicV1 (only Quic, code 460),
+    // while tentacle has QuicV1 (code 461). However, the /ip4/.../udp/...
+    // prefix is shared and must produce identical binary encodings.
+    let full_source = "/ip4/127.0.0.1/udp/4433/quic-v1";
+    let prefix_source = "/ip4/127.0.0.1/udp/4433";
+
+    let addr_t: Multiaddr = full_source.parse().unwrap();
+    let addr_p: OtherMultiaddr = prefix_source.parse().unwrap();
+
+    let bytes_t = addr_t.to_vec();
+    let bytes_p = addr_p.to_vec();
+
+    // The tentacle bytes should start with the same prefix as parity
+    assert!(
+        bytes_t.starts_with(&bytes_p),
+        "tentacle quic-v1 address bytes should start with the same ip4+udp prefix as parity"
+    );
+
+    // The extra bytes after the prefix are the QuicV1 protocol code (varint 461 = 0x01cd)
+    let quicv1_suffix = &bytes_t[bytes_p.len()..];
+    assert!(
+        !quicv1_suffix.is_empty(),
+        "quic-v1 should add extra bytes beyond the udp prefix"
+    );
+}
+
+#[test]
+fn compat_quicv1_tentacle_bytes_not_decodable_by_parity() {
+    // Since parity doesn't know QuicV1, decoding the full address should fail
+    let source = "/ip4/127.0.0.1/udp/4433/quic-v1";
+    let addr_t: Multiaddr = source.parse().unwrap();
+    let bytes = addr_t.to_vec();
+
+    // parity should fail to decode the full bytes (unknown protocol code 461)
+    assert!(
+        OtherMultiaddr::try_from(bytes).is_err(),
+        "parity should not be able to decode quic-v1 (protocol code 461 is unknown to it)"
+    );
+}
+
+#[test]
+fn compat_quicv1_string_not_parseable_by_parity() {
+    // parity doesn't recognize "quic-v1" as a protocol string
+    assert!(
+        "/ip4/127.0.0.1/udp/4433/quic-v1"
+            .parse::<OtherMultiaddr>()
+            .is_err(),
+        "parity should not parse quic-v1 string"
+    );
+}
+
+#[test]
+fn compat_parity_quic_not_parseable_by_tentacle() {
+    // Conversely, tentacle doesn't have the legacy Quic protocol (code 460)
+    assert!(
+        "/ip4/127.0.0.1/udp/4433/quic".parse::<Multiaddr>().is_err(),
+        "tentacle should not parse legacy /quic string"
+    );
+
+    // Also verify binary: parity's /quic bytes should fail to decode in tentacle
+    let addr_p: OtherMultiaddr = "/ip4/127.0.0.1/udp/4433/quic".parse().unwrap();
+    let bytes = addr_p.to_vec();
+    assert!(
+        Multiaddr::try_from(bytes).is_err(),
+        "tentacle should not decode parity's /quic binary (protocol code 460 is unknown to it)"
+    );
+}
+
+#[test]
+fn compat_udp_hex_roundtrip_cross_crate() {
+    // Verify that hex-encoded bytes from one crate decode correctly in the other
+    let source = "/ip4/10.0.0.1/udp/12345";
+    let addr_t: Multiaddr = source.parse().unwrap();
+    let hex = HEXUPPER.encode(&addr_t.to_vec());
+
+    let bytes_from_hex = HEXUPPER.decode(hex.as_bytes()).unwrap();
+    let decoded_p = OtherMultiaddr::try_from(bytes_from_hex).unwrap();
+    assert_eq!(decoded_p.to_string(), source);
+}
+
+#[test]
+fn compat_udp_with_p2p_suffix() {
+    // Full address with UDP + P2P suffix should be identical between crates
+    let source = "/ip4/47.111.169.36/udp/8111/p2p/QmNQ4jky6uVqLDrPU7snqxARuNGWNLgSrTnssbRuy3ij2W";
+
+    let mut addr_t: Multiaddr = source.parse().unwrap();
+    let mut addr_p: OtherMultiaddr = source.parse().unwrap();
+
+    assert_eq!(addr_t.to_string(), addr_p.to_string());
+    assert_eq!(addr_t.to_vec(), addr_p.to_vec());
+
+    // Pop P2P and compare the inner bytes
+    let p_t = addr_t.pop().unwrap();
+    let p_p = addr_p.pop().unwrap();
+
+    match (p_t, p_p) {
+        (Protocol::P2P(s_1), OtherProtocol::P2p(s_2)) => assert_eq!(s_1.as_ref(), s_2.to_bytes()),
+        e => panic!("expected P2P, got {:?}", e),
+    }
+
+    // After popping P2P, the remaining UDP part should match
+    let u_t = addr_t.pop().unwrap();
+    let u_p = addr_p.pop().unwrap();
+
+    match (u_t, u_p) {
+        (Protocol::Udp(a), OtherProtocol::Udp(b)) => assert_eq!(a, b),
+        e => panic!("expected Udp, got {:?}", e),
+    }
 }


### PR DESCRIPTION
## Summary

This PR is **part 1 of 5** in the series to add native QUIC transport support to Tentacle, as outlined in [#428](https://github.com/nervosnetwork/tentacle/issues/428).

### QUIC Implementation Roadmap

| PR | Title | Description |
|----|-------|-------------|
| **PR 1 (this)** | multiaddr: add `Udp` and `QuicV1` protocols | Extend the multiaddr crate to parse, serialize, and display `/udp/<port>` and `/quic-v1` protocol components |
| PR 2 | QUIC connectivity spike + self-signed certificate generation | Verify quinn + rustls + tokio integration; implement the dual-key model with a self-signed X.509 certificate carrying a private extension with `binding_sig` |
| PR 3 | Custom rustls certificate verifiers | Implement `ServerCertVerifier` and `ClientCertVerifier` that enforce Tentacle's identity model instead of CA-based validation |
| PR 4 | End-to-end QuicSession | Wire up `QuicBiStream`, `QuicEndpoint`, `QuicSession`, and the three integration points into `InnerService`; generalize `Substream<U>` with a stream type parameter |
| PR 5 | ServiceBuilder integration, example, and docs | Expose `ServiceBuilder::quic_config()`, add a runnable example, and write user-facing documentation |

### What this PR does

Adds `Udp(u16)` and `QuicV1` variants to the `Protocol` enum in `tentacle-multiaddr`, enabling addresses of the form `/ip4/<addr>/udp/<port>/quic-v1`.

Changes in `multiaddr/src/protocol.rs`:
- Two new protocol constants: `UDP = 0x0111`, `QUICV1 = 0x01cd`
- Six match branches added for `Udp`/`QuicV1`: `from_str_peek`, `from_bytes`, `write_to_bytes`, `acquire`, `Display::fmt`, and a new `Error::InvalidPort` variant for malformed UDP ports

Changes in `multiaddr/src/error.rs`:
- New `Error::InvalidPort` variant for UDP port parsing failures

No changes to any existing tentacle, yamux, or secio code. The `quic` feature flag and transport-layer address validation (e.g., rejecting DNS-based QUIC addresses) will be introduced in later PRs.

## Test plan

Tests are organized into three files:

**`multiaddr/tests/udp.rs`** — UDP protocol tests:
- [x] String parse and `Display` roundtrip: IPv4, IPv6, port 0, port 65535
- [x] Binary (`to_vec` / `TryFrom<Vec<u8>>`) roundtrip
- [x] Hex-encoded roundtrip
- [x] `push` / `pop` for `Udp` protocol component
- [x] `acquire()` produces `'static` protocols correctly
- [x] Error cases: missing port, non-numeric port, port overflow (65536), negative port

**`multiaddr/tests/quic.rs`** — QuicV1 protocol tests:
- [x] String parse and `Display` roundtrip: IPv4, IPv6, port 0, port 65535 (with `/quic-v1`)
- [x] QUIC address with `/p2p/<peer_id>` suffix
- [x] Binary roundtrip for IPv4 and IPv6 QUIC addresses
- [x] Hex-encoded roundtrip using the `ma_valid` helper (same pattern as existing onion tests)
- [x] `push` / `pop` for `QuicV1` protocol component
- [x] `acquire()` produces `'static` protocols correctly
- [x] DNS-based QUIC addresses (`/dns4/.../udp/.../quic-v1`) parse successfully at the multiaddr layer (rejection is deferred to the transport layer in PR 4)
- [x] Error cases: unknown protocol string

**`multiaddr/tests/quic.rs`** — Cross-crate compatibility tests (tentacle vs parity-multiaddr):
- [x] UDP string parse produces identical `to_string()` in both crates
- [x] UDP binary encoding is identical between crates
- [x] UDP binary cross-decode: bytes from one crate decode in the other
- [x] UDP protocol iteration produces matching components
- [x] UDP `push` / `pop` produces identical results
- [x] UDP port boundaries (0, 1, 1234, 65535) produce identical encodings
- [x] IPv6 + UDP binary encoding is identical
- [x] IPv6 + UDP cross-decode works both ways
- [x] `/quic-v1` shared prefix (`/ip4/.../udp/...`) is binary-identical with parity
- [x] `/quic-v1` full bytes are not decodable by parity (expected — parity lacks QuicV1)
- [x] `/quic-v1` string is not parseable by parity (expected)
- [x] parity's legacy `/quic` is not parseable by tentacle (expected)
- [x] UDP hex roundtrip cross-crate
- [x] UDP + P2P suffix with pop comparison

