### PR TITLE
quic: rustls verifier for certificate

### DIFF
--- a/tentacle/Cargo.toml
+++ b/tentacle/Cargo.toml
@@ -95,6 +95,10 @@ required-features = ["unstable"]
 name = "quic_simple"
 required-features = ["quic"]
 
+[[test]]
+name = "test_quic_verifier"
+required-features = ["quic"]
+
 [features]
 default = ["tokio-runtime", "tokio-timer", "quic"]
 ws = ["tokio-tungstenite", "httparse"]

--- a/tentacle/src/quic/identity.mol
+++ b/tentacle/src/quic/identity.mol
@@ -1,9 +1,7 @@
 vector Bytes <byte>;
-array PeerId [byte; 34];
 array Uint8 [byte; 1];
 table TentacleQuicIdentityV1 {
-    version:      Uint8,        
-    secio_pubkey: Bytes,     
-    peer_id:      PeerId,     
-    binding_sig:  Bytes,     
+    version:      Uint8,
+    secio_pubkey: Bytes,
+    binding_sig:  Bytes,
 }

--- a/tentacle/src/quic/identity.rs
+++ b/tentacle/src/quic/identity.rs
@@ -3,7 +3,7 @@ use secio::KeyProvider;
 
 use crate::quic::error::QuicErrorKind;
 use crate::quic::identity_mol::{
-    self, Bytes as MolBytes, TentacleQuicIdentityV1, TentacleQuicIdentityV1Reader, Uint8,
+    Bytes as MolBytes, TentacleQuicIdentityV1, TentacleQuicIdentityV1Reader, Uint8,
 };
 
 /// OID for tentacle QUIC identity X.509 extension.
@@ -24,9 +24,11 @@ pub struct TentacleQuicCert {
 ///   1. Generate a fresh Ed25519 TLS keypair (K_tls).
 ///   2. Extract the DER-encoded SubjectPublicKeyInfo of K_tls.
 ///   3. Compute `binding_sig = secp256k1_sign(K_secio, sha256(BINDING_DOMAIN || spki))`.
-///   4. Encode `(version, secio_pubkey, peer_id, binding_sig)` as a molecule
+///   4. Encode `(version, secio_pubkey, binding_sig)` as a molecule
 ///      `TentacleQuicIdentityV1` payload and attach it as a private X.509
-///      extension with OID `TENTACLE_QUIC_IDENT_OID`.
+///      extension with OID `TENTACLE_QUIC_IDENT_OID`. The `PeerId` is **not**
+///      stored in the payload — it is deterministically derived from
+///      `secio_pubkey` by both sides.
 ///   5. Self-sign the certificate.
 pub fn build_self_signed<K: KeyProvider>(key: &K) -> Result<TentacleQuicCert, QuicErrorKind> {
     // 1. Generate TLS keypair (K_tls)
@@ -48,11 +50,7 @@ pub fn build_self_signed<K: KeyProvider>(key: &K) -> Result<TentacleQuicCert, Qu
 
     // 4. Build molecule payload and wrap as a custom X.509 extension
     let secio_pubkey = key.pubkey();
-    let peer_id = secio::PublicKey::from_raw_key(secio_pubkey.clone())
-        .peer_id()
-        .into_bytes();
-
-    let payload = encode_identity_payload(&secio_pubkey, &peer_id, &binding_sig);
+    let payload = encode_identity_payload(&secio_pubkey, &binding_sig);
     let ext = rcgen::CustomExtension::from_oid_content(TENTACLE_QUIC_IDENT_OID, payload);
 
     // 5. Build CertificateParams and self-sign
@@ -77,12 +75,11 @@ pub fn build_self_signed<K: KeyProvider>(key: &K) -> Result<TentacleQuicCert, Qu
 }
 
 /// Encode the identity fields as a molecule `TentacleQuicIdentityV1` payload.
-fn encode_identity_payload(secio_pubkey: &[u8], peer_id: &[u8], binding_sig: &[u8]) -> Vec<u8> {
+fn encode_identity_payload(secio_pubkey: &[u8], binding_sig: &[u8]) -> Vec<u8> {
     let version = Uint8::new_builder().nth0(IDENTITY_VERSION).build();
     let secio_pubkey = MolBytes::new_builder()
         .extend(secio_pubkey.iter().copied().map(Into::into))
         .build();
-    let peer_id = identity_mol::PeerId::from(TryInto::<[u8; 34]>::try_into(peer_id).unwrap());
     let binding_sig = MolBytes::new_builder()
         .extend(binding_sig.iter().copied().map(Into::into))
         .build();
@@ -90,7 +87,6 @@ fn encode_identity_payload(secio_pubkey: &[u8], peer_id: &[u8], binding_sig: &[u
     TentacleQuicIdentityV1::new_builder()
         .version(version)
         .secio_pubkey(secio_pubkey)
-        .peer_id(peer_id)
         .binding_sig(binding_sig)
         .build()
         .as_bytes()
@@ -159,8 +155,6 @@ pub fn verify_binding<K: KeyProvider>(
 
 #[cfg(test)]
 mod tests {
-    use crate::quic::identity_mol::PeerId;
-
     use super::*;
     use secio::SecioKeyPair;
     use x509_parser::parse_x509_certificate;
@@ -182,18 +176,16 @@ mod tests {
         let version: u8 = identity.version().nth0().into();
         assert_eq!(version, IDENTITY_VERSION);
 
-        // secio_pubkey must round-trip
+        // secio_pubkey must round-trip exactly
         assert_eq!(
             identity.secio_pubkey().raw_data().as_ref(),
             key.public_key().inner_ref()
         );
 
-        // peer_id must be derivable from secio_pubkey
-        let expected_peer_id = key.public_key().peer_id().into_bytes();
-        assert_eq!(
-            identity.peer_id().raw_data().as_ref(),
-            expected_peer_id.as_slice()
-        );
+        // PeerId can be derived from secio_pubkey (no separate field stored)
+        let derived =
+            secio::PublicKey::from_raw_key(identity.secio_pubkey().raw_data().to_vec()).peer_id();
+        assert_eq!(derived, key.public_key().peer_id());
 
         // binding_sig must be non-empty
         assert!(!identity.binding_sig().raw_data().is_empty());
@@ -310,22 +302,18 @@ mod tests {
         // Build a properly-formatted molecule payload but with version = 2
         let key = SecioKeyPair::secp256k1_generated();
         let secio_pubkey = key.public_key().inner_ref().to_vec();
-        let peer_id = key.public_key().peer_id().into_bytes();
-        println!("peer id raw length {}", peer_id.len());
         let binding_sig = vec![0u8; 64];
 
         let version = Uint8::new_builder().nth0(2u8).build();
         let secio_pubkey_mol = MolBytes::new_builder()
             .extend(secio_pubkey.iter().copied().map(Into::into))
             .build();
-        let peer_id_mol = PeerId::from(TryInto::<[u8; 34]>::try_into(peer_id).unwrap());
         let sig_mol = MolBytes::new_builder()
             .extend(binding_sig.iter().copied().map(Into::into))
             .build();
         let payload = TentacleQuicIdentityV1::new_builder()
             .version(version)
             .secio_pubkey(secio_pubkey_mol)
-            .peer_id(peer_id_mol)
             .binding_sig(sig_mol)
             .build()
             .as_bytes()
@@ -351,21 +339,18 @@ mod tests {
         // Two extensions with the same OID — should be rejected
         let key = SecioKeyPair::secp256k1_generated();
         let secio_pubkey = key.public_key().inner_ref().to_vec();
-        let peer_id = key.public_key().peer_id().into_bytes();
 
         let build_payload = || {
             let version = Uint8::new_builder().nth0(IDENTITY_VERSION).build();
             let p_mol = MolBytes::new_builder()
                 .extend(secio_pubkey.iter().copied().map(Into::into))
                 .build();
-            let id_mol = PeerId::from(TryInto::<[u8; 34]>::try_into(peer_id.clone()).unwrap());
             let sig_mol = MolBytes::new_builder()
                 .extend(vec![0u8; 64].into_iter().map(Into::into))
                 .build();
             TentacleQuicIdentityV1::new_builder()
                 .version(version)
                 .secio_pubkey(p_mol)
-                .peer_id(id_mol)
                 .binding_sig(sig_mol)
                 .build()
                 .as_bytes()

--- a/tentacle/src/quic/identity_mol.rs
+++ b/tentacle/src/quic/identity_mol.rs
@@ -267,796 +267,6 @@ where
     }
 }
 #[derive(Clone)]
-pub struct PeerId(molecule::bytes::Bytes);
-impl ::core::fmt::LowerHex for PeerId {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        use molecule::hex_string;
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-        write!(f, "{}", hex_string(self.as_slice()))
-    }
-}
-impl ::core::fmt::Debug for PeerId {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        write!(f, "{}({:#x})", Self::NAME, self)
-    }
-}
-impl ::core::fmt::Display for PeerId {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        use molecule::hex_string;
-        let raw_data = hex_string(&self.raw_data());
-        write!(f, "{}(0x{})", Self::NAME, raw_data)
-    }
-}
-impl ::core::default::Default for PeerId {
-    fn default() -> Self {
-        let v = molecule::bytes::Bytes::from_static(&Self::DEFAULT_VALUE);
-        PeerId::new_unchecked(v)
-    }
-}
-impl PeerId {
-    const DEFAULT_VALUE: [u8; 34] = [
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0,
-    ];
-    pub const TOTAL_SIZE: usize = 34;
-    pub const ITEM_SIZE: usize = 1;
-    pub const ITEM_COUNT: usize = 34;
-    pub fn nth0(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(0..1))
-    }
-    pub fn nth1(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(1..2))
-    }
-    pub fn nth2(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(2..3))
-    }
-    pub fn nth3(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(3..4))
-    }
-    pub fn nth4(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(4..5))
-    }
-    pub fn nth5(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(5..6))
-    }
-    pub fn nth6(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(6..7))
-    }
-    pub fn nth7(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(7..8))
-    }
-    pub fn nth8(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(8..9))
-    }
-    pub fn nth9(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(9..10))
-    }
-    pub fn nth10(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(10..11))
-    }
-    pub fn nth11(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(11..12))
-    }
-    pub fn nth12(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(12..13))
-    }
-    pub fn nth13(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(13..14))
-    }
-    pub fn nth14(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(14..15))
-    }
-    pub fn nth15(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(15..16))
-    }
-    pub fn nth16(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(16..17))
-    }
-    pub fn nth17(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(17..18))
-    }
-    pub fn nth18(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(18..19))
-    }
-    pub fn nth19(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(19..20))
-    }
-    pub fn nth20(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(20..21))
-    }
-    pub fn nth21(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(21..22))
-    }
-    pub fn nth22(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(22..23))
-    }
-    pub fn nth23(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(23..24))
-    }
-    pub fn nth24(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(24..25))
-    }
-    pub fn nth25(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(25..26))
-    }
-    pub fn nth26(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(26..27))
-    }
-    pub fn nth27(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(27..28))
-    }
-    pub fn nth28(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(28..29))
-    }
-    pub fn nth29(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(29..30))
-    }
-    pub fn nth30(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(30..31))
-    }
-    pub fn nth31(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(31..32))
-    }
-    pub fn nth32(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(32..33))
-    }
-    pub fn nth33(&self) -> Byte {
-        Byte::new_unchecked(self.0.slice(33..34))
-    }
-    pub fn raw_data(&self) -> molecule::bytes::Bytes {
-        self.as_bytes()
-    }
-    pub fn as_reader<'r>(&'r self) -> PeerIdReader<'r> {
-        PeerIdReader::new_unchecked(self.as_slice())
-    }
-}
-impl molecule::prelude::Entity for PeerId {
-    type Builder = PeerIdBuilder;
-    const NAME: &'static str = "PeerId";
-    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
-        PeerId(data)
-    }
-    fn as_bytes(&self) -> molecule::bytes::Bytes {
-        self.0.clone()
-    }
-    fn as_slice(&self) -> &[u8] {
-        &self.0[..]
-    }
-    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
-        PeerIdReader::from_slice(slice).map(|reader| reader.to_entity())
-    }
-    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
-        PeerIdReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
-    }
-    fn new_builder() -> Self::Builder {
-        ::core::default::Default::default()
-    }
-    fn as_builder(self) -> Self::Builder {
-        Self::new_builder().set([
-            self.nth0(),
-            self.nth1(),
-            self.nth2(),
-            self.nth3(),
-            self.nth4(),
-            self.nth5(),
-            self.nth6(),
-            self.nth7(),
-            self.nth8(),
-            self.nth9(),
-            self.nth10(),
-            self.nth11(),
-            self.nth12(),
-            self.nth13(),
-            self.nth14(),
-            self.nth15(),
-            self.nth16(),
-            self.nth17(),
-            self.nth18(),
-            self.nth19(),
-            self.nth20(),
-            self.nth21(),
-            self.nth22(),
-            self.nth23(),
-            self.nth24(),
-            self.nth25(),
-            self.nth26(),
-            self.nth27(),
-            self.nth28(),
-            self.nth29(),
-            self.nth30(),
-            self.nth31(),
-            self.nth32(),
-            self.nth33(),
-        ])
-    }
-}
-#[derive(Clone, Copy)]
-pub struct PeerIdReader<'r>(&'r [u8]);
-impl<'r> ::core::fmt::LowerHex for PeerIdReader<'r> {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        use molecule::hex_string;
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-        write!(f, "{}", hex_string(self.as_slice()))
-    }
-}
-impl<'r> ::core::fmt::Debug for PeerIdReader<'r> {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        write!(f, "{}({:#x})", Self::NAME, self)
-    }
-}
-impl<'r> ::core::fmt::Display for PeerIdReader<'r> {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        use molecule::hex_string;
-        let raw_data = hex_string(&self.raw_data());
-        write!(f, "{}(0x{})", Self::NAME, raw_data)
-    }
-}
-impl<'r> PeerIdReader<'r> {
-    pub const TOTAL_SIZE: usize = 34;
-    pub const ITEM_SIZE: usize = 1;
-    pub const ITEM_COUNT: usize = 34;
-    pub fn nth0(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[0..1])
-    }
-    pub fn nth1(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[1..2])
-    }
-    pub fn nth2(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[2..3])
-    }
-    pub fn nth3(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[3..4])
-    }
-    pub fn nth4(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[4..5])
-    }
-    pub fn nth5(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[5..6])
-    }
-    pub fn nth6(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[6..7])
-    }
-    pub fn nth7(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[7..8])
-    }
-    pub fn nth8(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[8..9])
-    }
-    pub fn nth9(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[9..10])
-    }
-    pub fn nth10(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[10..11])
-    }
-    pub fn nth11(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[11..12])
-    }
-    pub fn nth12(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[12..13])
-    }
-    pub fn nth13(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[13..14])
-    }
-    pub fn nth14(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[14..15])
-    }
-    pub fn nth15(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[15..16])
-    }
-    pub fn nth16(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[16..17])
-    }
-    pub fn nth17(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[17..18])
-    }
-    pub fn nth18(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[18..19])
-    }
-    pub fn nth19(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[19..20])
-    }
-    pub fn nth20(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[20..21])
-    }
-    pub fn nth21(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[21..22])
-    }
-    pub fn nth22(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[22..23])
-    }
-    pub fn nth23(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[23..24])
-    }
-    pub fn nth24(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[24..25])
-    }
-    pub fn nth25(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[25..26])
-    }
-    pub fn nth26(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[26..27])
-    }
-    pub fn nth27(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[27..28])
-    }
-    pub fn nth28(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[28..29])
-    }
-    pub fn nth29(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[29..30])
-    }
-    pub fn nth30(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[30..31])
-    }
-    pub fn nth31(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[31..32])
-    }
-    pub fn nth32(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[32..33])
-    }
-    pub fn nth33(&self) -> ByteReader<'r> {
-        ByteReader::new_unchecked(&self.as_slice()[33..34])
-    }
-    pub fn raw_data(&self) -> &'r [u8] {
-        self.as_slice()
-    }
-}
-impl<'r> molecule::prelude::Reader<'r> for PeerIdReader<'r> {
-    type Entity = PeerId;
-    const NAME: &'static str = "PeerIdReader";
-    fn to_entity(&self) -> Self::Entity {
-        Self::Entity::new_unchecked(self.as_slice().to_owned().into())
-    }
-    fn new_unchecked(slice: &'r [u8]) -> Self {
-        PeerIdReader(slice)
-    }
-    fn as_slice(&self) -> &'r [u8] {
-        self.0
-    }
-    fn verify(slice: &[u8], _compatible: bool) -> molecule::error::VerificationResult<()> {
-        use molecule::verification_error as ve;
-        let slice_len = slice.len();
-        if slice_len != Self::TOTAL_SIZE {
-            return ve!(Self, TotalSizeNotMatch, Self::TOTAL_SIZE, slice_len);
-        }
-        Ok(())
-    }
-}
-#[derive(Clone)]
-pub struct PeerIdBuilder(pub(crate) [Byte; 34]);
-impl ::core::fmt::Debug for PeerIdBuilder {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        write!(f, "{}({:?})", Self::NAME, &self.0[..])
-    }
-}
-impl ::core::default::Default for PeerIdBuilder {
-    fn default() -> Self {
-        PeerIdBuilder([
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-            Byte::default(),
-        ])
-    }
-}
-impl PeerIdBuilder {
-    pub const TOTAL_SIZE: usize = 34;
-    pub const ITEM_SIZE: usize = 1;
-    pub const ITEM_COUNT: usize = 34;
-    pub fn set<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<[Byte; 34]>,
-    {
-        self.0 = v.into();
-        self
-    }
-    pub fn nth0<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[0] = v.into();
-        self
-    }
-    pub fn nth1<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[1] = v.into();
-        self
-    }
-    pub fn nth2<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[2] = v.into();
-        self
-    }
-    pub fn nth3<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[3] = v.into();
-        self
-    }
-    pub fn nth4<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[4] = v.into();
-        self
-    }
-    pub fn nth5<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[5] = v.into();
-        self
-    }
-    pub fn nth6<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[6] = v.into();
-        self
-    }
-    pub fn nth7<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[7] = v.into();
-        self
-    }
-    pub fn nth8<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[8] = v.into();
-        self
-    }
-    pub fn nth9<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[9] = v.into();
-        self
-    }
-    pub fn nth10<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[10] = v.into();
-        self
-    }
-    pub fn nth11<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[11] = v.into();
-        self
-    }
-    pub fn nth12<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[12] = v.into();
-        self
-    }
-    pub fn nth13<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[13] = v.into();
-        self
-    }
-    pub fn nth14<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[14] = v.into();
-        self
-    }
-    pub fn nth15<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[15] = v.into();
-        self
-    }
-    pub fn nth16<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[16] = v.into();
-        self
-    }
-    pub fn nth17<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[17] = v.into();
-        self
-    }
-    pub fn nth18<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[18] = v.into();
-        self
-    }
-    pub fn nth19<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[19] = v.into();
-        self
-    }
-    pub fn nth20<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[20] = v.into();
-        self
-    }
-    pub fn nth21<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[21] = v.into();
-        self
-    }
-    pub fn nth22<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[22] = v.into();
-        self
-    }
-    pub fn nth23<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[23] = v.into();
-        self
-    }
-    pub fn nth24<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[24] = v.into();
-        self
-    }
-    pub fn nth25<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[25] = v.into();
-        self
-    }
-    pub fn nth26<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[26] = v.into();
-        self
-    }
-    pub fn nth27<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[27] = v.into();
-        self
-    }
-    pub fn nth28<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[28] = v.into();
-        self
-    }
-    pub fn nth29<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[29] = v.into();
-        self
-    }
-    pub fn nth30<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[30] = v.into();
-        self
-    }
-    pub fn nth31<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[31] = v.into();
-        self
-    }
-    pub fn nth32<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[32] = v.into();
-        self
-    }
-    pub fn nth33<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<Byte>,
-    {
-        self.0[33] = v.into();
-        self
-    }
-}
-impl molecule::prelude::Builder for PeerIdBuilder {
-    type Entity = PeerId;
-    const NAME: &'static str = "PeerIdBuilder";
-    fn expected_length(&self) -> usize {
-        Self::TOTAL_SIZE
-    }
-    fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
-        writer.write_all(self.0[0].as_slice())?;
-        writer.write_all(self.0[1].as_slice())?;
-        writer.write_all(self.0[2].as_slice())?;
-        writer.write_all(self.0[3].as_slice())?;
-        writer.write_all(self.0[4].as_slice())?;
-        writer.write_all(self.0[5].as_slice())?;
-        writer.write_all(self.0[6].as_slice())?;
-        writer.write_all(self.0[7].as_slice())?;
-        writer.write_all(self.0[8].as_slice())?;
-        writer.write_all(self.0[9].as_slice())?;
-        writer.write_all(self.0[10].as_slice())?;
-        writer.write_all(self.0[11].as_slice())?;
-        writer.write_all(self.0[12].as_slice())?;
-        writer.write_all(self.0[13].as_slice())?;
-        writer.write_all(self.0[14].as_slice())?;
-        writer.write_all(self.0[15].as_slice())?;
-        writer.write_all(self.0[16].as_slice())?;
-        writer.write_all(self.0[17].as_slice())?;
-        writer.write_all(self.0[18].as_slice())?;
-        writer.write_all(self.0[19].as_slice())?;
-        writer.write_all(self.0[20].as_slice())?;
-        writer.write_all(self.0[21].as_slice())?;
-        writer.write_all(self.0[22].as_slice())?;
-        writer.write_all(self.0[23].as_slice())?;
-        writer.write_all(self.0[24].as_slice())?;
-        writer.write_all(self.0[25].as_slice())?;
-        writer.write_all(self.0[26].as_slice())?;
-        writer.write_all(self.0[27].as_slice())?;
-        writer.write_all(self.0[28].as_slice())?;
-        writer.write_all(self.0[29].as_slice())?;
-        writer.write_all(self.0[30].as_slice())?;
-        writer.write_all(self.0[31].as_slice())?;
-        writer.write_all(self.0[32].as_slice())?;
-        writer.write_all(self.0[33].as_slice())?;
-        Ok(())
-    }
-    fn build(&self) -> Self::Entity {
-        let mut inner = Vec::with_capacity(self.expected_length());
-        self.write(&mut inner)
-            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
-        PeerId::new_unchecked(inner.into())
-    }
-}
-impl From<[Byte; 34usize]> for PeerId {
-    fn from(value: [Byte; 34usize]) -> Self {
-        Self::new_builder().set(value).build()
-    }
-}
-impl ::core::convert::TryFrom<&[Byte]> for PeerId {
-    type Error = ::core::array::TryFromSliceError;
-    fn try_from(value: &[Byte]) -> Result<Self, ::core::array::TryFromSliceError> {
-        Ok(Self::new_builder()
-            .set(<&[Byte; 34usize]>::try_from(value)?.clone())
-            .build())
-    }
-}
-impl From<PeerId> for [Byte; 34usize] {
-    #[track_caller]
-    fn from(value: PeerId) -> Self {
-        [
-            value.nth0(),
-            value.nth1(),
-            value.nth2(),
-            value.nth3(),
-            value.nth4(),
-            value.nth5(),
-            value.nth6(),
-            value.nth7(),
-            value.nth8(),
-            value.nth9(),
-            value.nth10(),
-            value.nth11(),
-            value.nth12(),
-            value.nth13(),
-            value.nth14(),
-            value.nth15(),
-            value.nth16(),
-            value.nth17(),
-            value.nth18(),
-            value.nth19(),
-            value.nth20(),
-            value.nth21(),
-            value.nth22(),
-            value.nth23(),
-            value.nth24(),
-            value.nth25(),
-            value.nth26(),
-            value.nth27(),
-            value.nth28(),
-            value.nth29(),
-            value.nth30(),
-            value.nth31(),
-            value.nth32(),
-            value.nth33(),
-        ]
-    }
-}
-impl From<[u8; 34usize]> for PeerId {
-    fn from(value: [u8; 34usize]) -> Self {
-        PeerIdReader::new_unchecked(&value).to_entity()
-    }
-}
-impl ::core::convert::TryFrom<&[u8]> for PeerId {
-    type Error = ::core::array::TryFromSliceError;
-    fn try_from(value: &[u8]) -> Result<Self, ::core::array::TryFromSliceError> {
-        Ok(<[u8; 34usize]>::try_from(value)?.into())
-    }
-}
-impl From<PeerId> for [u8; 34usize] {
-    #[track_caller]
-    fn from(value: PeerId) -> Self {
-        ::core::convert::TryFrom::try_from(value.as_slice()).unwrap()
-    }
-}
-impl<'a> From<PeerIdReader<'a>> for &'a [u8; 34usize] {
-    #[track_caller]
-    fn from(value: PeerIdReader<'a>) -> Self {
-        ::core::convert::TryFrom::try_from(value.as_slice()).unwrap()
-    }
-}
-impl<'a> From<&'a PeerIdReader<'a>> for &'a [u8; 34usize] {
-    #[track_caller]
-    fn from(value: &'a PeerIdReader<'a>) -> Self {
-        ::core::convert::TryFrom::try_from(value.as_slice()).unwrap()
-    }
-}
-#[derive(Clone)]
 pub struct Uint8(molecule::bytes::Bytes);
 impl ::core::fmt::LowerHex for Uint8 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
@@ -1297,7 +507,6 @@ impl ::core::fmt::Display for TentacleQuicIdentityV1 {
         write!(f, "{} {{ ", Self::NAME)?;
         write!(f, "{}: {}", "version", self.version())?;
         write!(f, ", {}: {}", "secio_pubkey", self.secio_pubkey())?;
-        write!(f, ", {}: {}", "peer_id", self.peer_id())?;
         write!(f, ", {}: {}", "binding_sig", self.binding_sig())?;
         let extra_count = self.count_extra_fields();
         if extra_count != 0 {
@@ -1313,12 +522,10 @@ impl ::core::default::Default for TentacleQuicIdentityV1 {
     }
 }
 impl TentacleQuicIdentityV1 {
-    const DEFAULT_VALUE: [u8; 63] = [
-        63, 0, 0, 0, 20, 0, 0, 0, 21, 0, 0, 0, 25, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0,
+    const DEFAULT_VALUE: [u8; 25] = [
+        25, 0, 0, 0, 16, 0, 0, 0, 17, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ];
-    pub const FIELD_COUNT: usize = 4;
+    pub const FIELD_COUNT: usize = 3;
     pub fn total_size(&self) -> usize {
         molecule::unpack_number(self.as_slice()) as usize
     }
@@ -1347,17 +554,11 @@ impl TentacleQuicIdentityV1 {
         let end = molecule::unpack_number(&slice[12..]) as usize;
         Bytes::new_unchecked(self.0.slice(start..end))
     }
-    pub fn peer_id(&self) -> PeerId {
-        let slice = self.as_slice();
-        let start = molecule::unpack_number(&slice[12..]) as usize;
-        let end = molecule::unpack_number(&slice[16..]) as usize;
-        PeerId::new_unchecked(self.0.slice(start..end))
-    }
     pub fn binding_sig(&self) -> Bytes {
         let slice = self.as_slice();
-        let start = molecule::unpack_number(&slice[16..]) as usize;
+        let start = molecule::unpack_number(&slice[12..]) as usize;
         if self.has_extra_fields() {
-            let end = molecule::unpack_number(&slice[20..]) as usize;
+            let end = molecule::unpack_number(&slice[16..]) as usize;
             Bytes::new_unchecked(self.0.slice(start..end))
         } else {
             Bytes::new_unchecked(self.0.slice(start..))
@@ -1392,7 +593,6 @@ impl molecule::prelude::Entity for TentacleQuicIdentityV1 {
         Self::new_builder()
             .version(self.version())
             .secio_pubkey(self.secio_pubkey())
-            .peer_id(self.peer_id())
             .binding_sig(self.binding_sig())
     }
 }
@@ -1417,7 +617,6 @@ impl<'r> ::core::fmt::Display for TentacleQuicIdentityV1Reader<'r> {
         write!(f, "{} {{ ", Self::NAME)?;
         write!(f, "{}: {}", "version", self.version())?;
         write!(f, ", {}: {}", "secio_pubkey", self.secio_pubkey())?;
-        write!(f, ", {}: {}", "peer_id", self.peer_id())?;
         write!(f, ", {}: {}", "binding_sig", self.binding_sig())?;
         let extra_count = self.count_extra_fields();
         if extra_count != 0 {
@@ -1427,7 +626,7 @@ impl<'r> ::core::fmt::Display for TentacleQuicIdentityV1Reader<'r> {
     }
 }
 impl<'r> TentacleQuicIdentityV1Reader<'r> {
-    pub const FIELD_COUNT: usize = 4;
+    pub const FIELD_COUNT: usize = 3;
     pub fn total_size(&self) -> usize {
         molecule::unpack_number(self.as_slice()) as usize
     }
@@ -1456,17 +655,11 @@ impl<'r> TentacleQuicIdentityV1Reader<'r> {
         let end = molecule::unpack_number(&slice[12..]) as usize;
         BytesReader::new_unchecked(&self.as_slice()[start..end])
     }
-    pub fn peer_id(&self) -> PeerIdReader<'r> {
-        let slice = self.as_slice();
-        let start = molecule::unpack_number(&slice[12..]) as usize;
-        let end = molecule::unpack_number(&slice[16..]) as usize;
-        PeerIdReader::new_unchecked(&self.as_slice()[start..end])
-    }
     pub fn binding_sig(&self) -> BytesReader<'r> {
         let slice = self.as_slice();
-        let start = molecule::unpack_number(&slice[16..]) as usize;
+        let start = molecule::unpack_number(&slice[12..]) as usize;
         if self.has_extra_fields() {
-            let end = molecule::unpack_number(&slice[20..]) as usize;
+            let end = molecule::unpack_number(&slice[16..]) as usize;
             BytesReader::new_unchecked(&self.as_slice()[start..end])
         } else {
             BytesReader::new_unchecked(&self.as_slice()[start..])
@@ -1521,8 +714,7 @@ impl<'r> molecule::prelude::Reader<'r> for TentacleQuicIdentityV1Reader<'r> {
         }
         Uint8Reader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
         BytesReader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
-        PeerIdReader::verify(&slice[offsets[2]..offsets[3]], compatible)?;
-        BytesReader::verify(&slice[offsets[3]..offsets[4]], compatible)?;
+        BytesReader::verify(&slice[offsets[2]..offsets[3]], compatible)?;
         Ok(())
     }
 }
@@ -1530,11 +722,10 @@ impl<'r> molecule::prelude::Reader<'r> for TentacleQuicIdentityV1Reader<'r> {
 pub struct TentacleQuicIdentityV1Builder {
     pub(crate) version: Uint8,
     pub(crate) secio_pubkey: Bytes,
-    pub(crate) peer_id: PeerId,
     pub(crate) binding_sig: Bytes,
 }
 impl TentacleQuicIdentityV1Builder {
-    pub const FIELD_COUNT: usize = 4;
+    pub const FIELD_COUNT: usize = 3;
     pub fn version<T>(mut self, v: T) -> Self
     where
         T: ::core::convert::Into<Uint8>,
@@ -1547,13 +738,6 @@ impl TentacleQuicIdentityV1Builder {
         T: ::core::convert::Into<Bytes>,
     {
         self.secio_pubkey = v.into();
-        self
-    }
-    pub fn peer_id<T>(mut self, v: T) -> Self
-    where
-        T: ::core::convert::Into<PeerId>,
-    {
-        self.peer_id = v.into();
         self
     }
     pub fn binding_sig<T>(mut self, v: T) -> Self
@@ -1571,7 +755,6 @@ impl molecule::prelude::Builder for TentacleQuicIdentityV1Builder {
         molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
             + self.version.as_slice().len()
             + self.secio_pubkey.as_slice().len()
-            + self.peer_id.as_slice().len()
             + self.binding_sig.as_slice().len()
     }
     fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
@@ -1582,8 +765,6 @@ impl molecule::prelude::Builder for TentacleQuicIdentityV1Builder {
         offsets.push(total_size);
         total_size += self.secio_pubkey.as_slice().len();
         offsets.push(total_size);
-        total_size += self.peer_id.as_slice().len();
-        offsets.push(total_size);
         total_size += self.binding_sig.as_slice().len();
         writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
         for offset in offsets.into_iter() {
@@ -1591,7 +772,6 @@ impl molecule::prelude::Builder for TentacleQuicIdentityV1Builder {
         }
         writer.write_all(self.version.as_slice())?;
         writer.write_all(self.secio_pubkey.as_slice())?;
-        writer.write_all(self.peer_id.as_slice())?;
         writer.write_all(self.binding_sig.as_slice())?;
         Ok(())
     }

--- a/tentacle/src/quic/mod.rs
+++ b/tentacle/src/quic/mod.rs
@@ -9,3 +9,7 @@ pub mod identity;
 
 /// Error types of QUIC protocol
 pub mod error;
+
+#[allow(missing_docs)]
+/// Verifier for rustls
+pub mod verifier;

--- a/tentacle/src/quic/verifier.rs
+++ b/tentacle/src/quic/verifier.rs
@@ -10,17 +10,16 @@
 //! 2. The leaf certificate's validity period covers the current time.
 //! 3. The leaf contains **exactly one** X.509 extension with OID
 //!    [`TENTACLE_QUIC_IDENT_OID`]. The payload decodes as a
-//!    molecule `TentacleQuicIdentityV1` structure with `version == 1`.
+//!    molecule `TentacleQuicIdentityV1 { version, secio_pubkey, binding_sig }`
+//!    with `version == 1`. The peer's `PeerId` is **not** stored in the
+//!    payload — it is deterministically derived from `secio_pubkey` by both
+//!    sides at verification time.
 //! 4. The secp256k1 signature in `binding_sig` is valid for
 //!    `sha256(BINDING_DOMAIN || leaf_spki_der)` under `secio_pubkey`,
 //!    proving the TLS key and the secio identity share an owner.
 //! 5. For a client dialling a target address that contains `/p2p/<expected>`,
 //!    `expected` must equal `PeerId::from_public_key(secio_pubkey)`
 //!    (server-side verifier skips this step).
-//!
-//! Note: the `peer_id` field in the extension payload is **not** verified
-//! against `secio_pubkey` — it is a redundant deterministic derivation.
-//! The verifier always derives `PeerId` from `secio_pubkey` directly.
 //!
 //! SAN and hostname are never checked.
 //!
@@ -324,9 +323,7 @@ mod tests {
     use std::time::Duration;
 
     use crate::quic::identity::{IDENTITY_VERSION, TENTACLE_QUIC_IDENT_OID, build_self_signed};
-    use crate::quic::identity_mol::{
-        Bytes as MolBytes, PeerId as MolPeerId, TentacleQuicIdentityV1, Uint8,
-    };
+    use crate::quic::identity_mol::{Bytes as MolBytes, TentacleQuicIdentityV1, Uint8};
 
     fn now() -> UnixTime {
         UnixTime::now()
@@ -354,22 +351,11 @@ mod tests {
     }
 
     /// Molecule-encode an identity payload with arbitrary field values.
-    ///
-    /// `peer_id` must be exactly 34 bytes (the fixed multihash length).
-    fn encode_identity(
-        version: u8,
-        secio_pubkey: &[u8],
-        peer_id: &[u8],
-        binding_sig: &[u8],
-    ) -> Vec<u8> {
+    fn encode_identity(version: u8, secio_pubkey: &[u8], binding_sig: &[u8]) -> Vec<u8> {
         let v = Uint8::new_builder().nth0(version).build();
         let sp = MolBytes::new_builder()
             .extend(secio_pubkey.iter().copied().map(Into::into))
             .build();
-        let pid_array: [u8; 34] = peer_id
-            .try_into()
-            .expect("peer_id must be 34 bytes for the molecule PeerId array");
-        let pid = MolPeerId::from(pid_array);
         let sig = MolBytes::new_builder()
             .extend(binding_sig.iter().copied().map(Into::into))
             .build();
@@ -377,7 +363,6 @@ mod tests {
         TentacleQuicIdentityV1::new_builder()
             .version(v)
             .secio_pubkey(sp)
-            .peer_id(pid)
             .binding_sig(sig)
             .build()
             .as_bytes()
@@ -466,9 +451,8 @@ mod tests {
     fn test_server_verify_wrong_version() {
         let key = SecioKeyPair::secp256k1_generated();
         let pubkey = key.public_key().inner_ref().to_vec();
-        let peer_id = key.public_key().peer_id().into_bytes();
 
-        let payload = encode_identity(2, &pubkey, &peer_id, &[0u8; 64]);
+        let payload = encode_identity(2, &pubkey, &[0u8; 64]);
         let cert_bytes = build_cert_with_payload(payload);
 
         let verifier = TentacleQuicServerCertVerifier::new(key, None);
@@ -482,11 +466,10 @@ mod tests {
     fn test_server_verify_binding_sig_invalid() {
         let key = SecioKeyPair::secp256k1_generated();
         let pubkey = key.public_key().inner_ref().to_vec();
-        let peer_id = key.public_key().peer_id().into_bytes();
 
         // A syntactically reasonable but semantically wrong signature.
         let bogus_sig = vec![0xab; 64];
-        let payload = encode_identity(IDENTITY_VERSION, &pubkey, &peer_id, &bogus_sig);
+        let payload = encode_identity(IDENTITY_VERSION, &pubkey, &bogus_sig);
         let cert_bytes = build_cert_with_payload(payload);
 
         let verifier = TentacleQuicServerCertVerifier::new(key, None);

--- a/tentacle/src/quic/verifier.rs
+++ b/tentacle/src/quic/verifier.rs
@@ -1,0 +1,571 @@
+//! # Tentacle QUIC certificate verifiers
+//!
+//! Custom `rustls` verifiers that replace the conventional CA / hostname model
+//! with the Tentacle identity binding described in [plan.md §4.4].
+//!
+//! A peer certificate is accepted if and only if all of the following hold:
+//!
+//! 1. The presented certificate chain contains **exactly one** leaf. No
+//!    intermediate certificates are allowed.
+//! 2. The leaf certificate's validity period covers the current time.
+//! 3. The leaf contains **exactly one** X.509 extension with OID
+//!    [`TENTACLE_QUIC_IDENT_OID`]. The payload decodes as a
+//!    molecule `TentacleQuicIdentityV1` structure with `version == 1`.
+//! 4. The secp256k1 signature in `binding_sig` is valid for
+//!    `sha256(BINDING_DOMAIN || leaf_spki_der)` under `secio_pubkey`,
+//!    proving the TLS key and the secio identity share an owner.
+//! 5. For a client dialling a target address that contains `/p2p/<expected>`,
+//!    `expected` must equal `PeerId::from_public_key(secio_pubkey)`
+//!    (server-side verifier skips this step).
+//!
+//! Note: the `peer_id` field in the extension payload is **not** verified
+//! against `secio_pubkey` — it is a redundant deterministic derivation.
+//! The verifier always derives `PeerId` from `secio_pubkey` directly.
+//!
+//! SAN and hostname are never checked.
+//!
+//! Once the certificate passes the above checks, per-TLS-message signature
+//! verification (`verify_tls12_signature` / `verify_tls13_signature`) and the
+//! advertised signature-scheme list are delegated to the `rustls` default
+//! crypto provider (currently `aws_lc_rs`, matching the `tls` feature).
+//!
+//! [plan.md §4.4]: https://github.com/nervosnetwork/tentacle/blob/master/plan.md
+//! [`TENTACLE_QUIC_IDENT_OID`]: crate::quic::identity::TENTACLE_QUIC_IDENT_OID
+
+use std::sync::Arc;
+
+use rustls::{
+    DigitallySignedStruct, DistinguishedName, Error as RustlsError, SignatureScheme,
+    client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
+    crypto::{CryptoProvider, verify_tls12_signature, verify_tls13_signature},
+    pki_types::{CertificateDer, ServerName, UnixTime},
+    server::danger::{ClientCertVerified, ClientCertVerifier},
+};
+use secio::KeyProvider;
+
+use crate::quic::identity::{extract_identity, verify_binding};
+
+// ─────────────────────────────────────── server side ────────────────────────────────────────
+
+/// Verifies a **server** certificate presented during the TLS handshake of a
+/// client-initiated QUIC connection.
+///
+/// Holds a reference to the local `KeyProvider` so it can dispatch the
+/// secp256k1 signature verification in [`verify_binding`] — no private key
+/// material is ever read, only `KeyProvider::verify_ecdsa` is used.
+///
+/// If the dial target multiaddr contains `/p2p/<peer_id>`, construct the
+/// verifier with `Some(peer_id)` so the TLS handshake fails with
+/// `rustls::Error::General` when the server's certificate does not bind to the
+/// expected peer.
+pub struct TentacleQuicServerCertVerifier<K: KeyProvider> {
+    /// PeerId extracted from the dial target multiaddr (`/p2p/<peer_id>`).
+    /// `None` means the dialer did not pin a specific peer.
+    expected_peer_id: Option<secio::PeerId>,
+
+    /// Local `KeyProvider`, used only to dispatch `verify_ecdsa`.
+    local_key: K,
+
+    /// Crypto provider used for TLS signature verification and to populate
+    /// `supported_verify_schemes`.
+    crypto_provider: Arc<CryptoProvider>,
+}
+
+impl<K: KeyProvider> TentacleQuicServerCertVerifier<K> {
+    /// Build a new verifier with the default `aws_lc_rs` crypto provider.
+    pub fn new(local_key: K, expected_peer_id: Option<secio::PeerId>) -> Self {
+        Self {
+            expected_peer_id,
+            local_key,
+            crypto_provider: Arc::new(rustls::crypto::aws_lc_rs::default_provider()),
+        }
+    }
+}
+
+impl<K: KeyProvider> std::fmt::Debug for TentacleQuicServerCertVerifier<K> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TentacleQuicServerCertVerifier")
+            .field("expected_peer_id", &self.expected_peer_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<K: KeyProvider> ServerCertVerifier for TentacleQuicServerCertVerifier<K> {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        now: UnixTime,
+    ) -> Result<ServerCertVerified, RustlsError> {
+        verify_tentacle_cert(
+            &self.local_key,
+            end_entity,
+            intermediates,
+            now,
+            self.expected_peer_id.as_ref(),
+        )?;
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, RustlsError> {
+        verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &self.crypto_provider.signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, RustlsError> {
+        verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &self.crypto_provider.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.crypto_provider
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+// ─────────────────────────────────────── client side ────────────────────────────────────────
+
+/// Verifies a **client** certificate presented during the TLS handshake of an
+/// incoming QUIC connection on a server.
+///
+/// Identity extraction and binding checks are identical to the server verifier
+/// above. There is no `expected_peer_id` because the server does not know in
+/// advance which peer will connect — any well-formed Tentacle identity is
+/// accepted and the resulting `PeerId` is surfaced to `InnerService` via
+/// `SessionContext.remote_pubkey`.
+///
+/// Client authentication is **mandatory** — a plain TLS client cannot connect.
+pub struct TentacleQuicClientCertVerifier<K: KeyProvider> {
+    /// Local `KeyProvider`, used only to dispatch `verify_ecdsa`.
+    local_key: K,
+
+    /// Crypto provider used for TLS signature verification and to populate
+    /// `supported_verify_schemes`.
+    crypto_provider: Arc<CryptoProvider>,
+}
+
+impl<K: KeyProvider> TentacleQuicClientCertVerifier<K> {
+    /// Build a new verifier with the default `aws_lc_rs` crypto provider.
+    pub fn new(local_key: K) -> Self {
+        Self {
+            local_key,
+            crypto_provider: Arc::new(rustls::crypto::aws_lc_rs::default_provider()),
+        }
+    }
+}
+
+impl<K: KeyProvider> std::fmt::Debug for TentacleQuicClientCertVerifier<K> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TentacleQuicClientCertVerifier")
+            .finish_non_exhaustive()
+    }
+}
+
+impl<K: KeyProvider> ClientCertVerifier for TentacleQuicClientCertVerifier<K> {
+    fn offer_client_auth(&self) -> bool {
+        true
+    }
+
+    fn client_auth_mandatory(&self) -> bool {
+        true
+    }
+
+    fn root_hint_subjects(&self) -> &[DistinguishedName] {
+        &[]
+    }
+
+    fn verify_client_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        intermediates: &[CertificateDer<'_>],
+        now: UnixTime,
+    ) -> Result<ClientCertVerified, RustlsError> {
+        verify_tentacle_cert(&self.local_key, end_entity, intermediates, now, None)?;
+        Ok(ClientCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, RustlsError> {
+        verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &self.crypto_provider.signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, RustlsError> {
+        verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &self.crypto_provider.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.crypto_provider
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+// ─────────────────────────────────────── shared check ───────────────────────────────────────
+
+/// Run the tentacle identity checks shared by both verifiers (steps 1–10 of
+/// plan.md §4.4). The returned `rustls::Error` is what propagates into the
+/// QUIC handshake failure visible to the application as a connection abort.
+fn verify_tentacle_cert<K: KeyProvider>(
+    local_key: &K,
+    end_entity: &CertificateDer<'_>,
+    intermediates: &[CertificateDer<'_>],
+    now: UnixTime,
+    expected_peer_id: Option<&secio::PeerId>,
+) -> Result<(), RustlsError> {
+    // Step 1: non-empty chain. `end_entity` is non-optional in the rustls API,
+    //         so presence is already guaranteed.
+
+    // Step 2: no intermediates — the Tentacle identity must live on a
+    //         single self-signed leaf.
+    if !intermediates.is_empty() {
+        return Err(RustlsError::General(
+            "tentacle quic cert chain must contain exactly one leaf certificate".to_string(),
+        ));
+    }
+
+    // Steps 3 & 4: parse and check validity window.
+    let leaf_der = end_entity.as_ref();
+    let (_, parsed) = x509_parser::parse_x509_certificate(leaf_der)
+        .map_err(|e| RustlsError::General(format!("failed to parse leaf certificate: {}", e)))?;
+
+    let now_secs = now.as_secs() as i64;
+    let not_before = parsed.validity().not_before.timestamp();
+    let not_after = parsed.validity().not_after.timestamp();
+    if now_secs < not_before || now_secs > not_after {
+        return Err(RustlsError::General(
+            "tentacle quic cert is outside its validity period".to_string(),
+        ));
+    }
+
+    // Steps 5–7: locate the private extension, molecule-decode it, validate
+    //            version. All handled inside `extract_identity`.
+    let identity = extract_identity(leaf_der)
+        .map_err(|e| RustlsError::General(format!("identity extension: {}", e)))?;
+
+    // Reconstruct the secio public key and derive PeerId from the extension.
+    // Note: we intentionally skip checking the `peer_id` field in the extension
+    // against `secio_pubkey` — it is a redundant deterministic derivation with
+    // no security value. The verifier always derives PeerId from `secio_pubkey`.
+    let secio_pubkey_bytes = identity.secio_pubkey().raw_data();
+    let secio_pubkey = secio::PublicKey::from_raw_key(secio_pubkey_bytes.to_vec());
+    let derived_peer_id = secio_pubkey.peer_id();
+
+    // Step 8: pull SPKI DER from the parsed cert for the binding check.
+    let spki_der = parsed.public_key().raw;
+
+    // Step 9: verify the secio binding signature over the SPKI DER.
+    let binding_sig = identity.binding_sig().raw_data();
+    verify_binding(local_key, &secio_pubkey, spki_der, binding_sig.as_ref())
+        .map_err(|e| RustlsError::General(format!("binding signature invalid: {}", e)))?;
+
+    // Step 10: client-only pinned peer_id check. Server-side verifier passes
+    //          `None` here.
+    if let Some(expected) = expected_peer_id {
+        if *expected != derived_peer_id {
+            return Err(RustlsError::General(format!(
+                "tentacle identity: expected peer_id {}, got {}",
+                expected, derived_peer_id
+            )));
+        }
+    }
+
+    // SAN and hostname checks are intentionally omitted — the identity model
+    // above is sufficient to bind the TLS key to the tentacle PeerId.
+    Ok(())
+}
+
+// ──────────────────────────────────────────── tests ─────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use molecule::prelude::{Builder, Entity};
+    use secio::SecioKeyPair;
+    use std::time::Duration;
+
+    use crate::quic::identity::{IDENTITY_VERSION, TENTACLE_QUIC_IDENT_OID, build_self_signed};
+    use crate::quic::identity_mol::{
+        Bytes as MolBytes, PeerId as MolPeerId, TentacleQuicIdentityV1, Uint8,
+    };
+
+    fn now() -> UnixTime {
+        UnixTime::now()
+    }
+
+    fn valid_server_name() -> ServerName<'static> {
+        ServerName::try_from("tentacle.invalid").unwrap()
+    }
+
+    /// Build a cert whose tentacle extension carries an arbitrary payload.
+    fn build_cert_with_payload(payload: Vec<u8>) -> Vec<u8> {
+        let tls_keypair = rcgen::KeyPair::generate_for(&rcgen::PKCS_ED25519).unwrap();
+        let mut params =
+            rcgen::CertificateParams::new(vec!["tentacle.invalid".to_string()]).unwrap();
+        let ext = rcgen::CustomExtension::from_oid_content(TENTACLE_QUIC_IDENT_OID, payload);
+        params.custom_extensions.push(ext);
+        params.self_signed(&tls_keypair).unwrap().der().to_vec()
+    }
+
+    /// Build a self-signed cert that does NOT carry the tentacle extension.
+    fn build_cert_without_extension() -> Vec<u8> {
+        let tls_keypair = rcgen::KeyPair::generate_for(&rcgen::PKCS_ED25519).unwrap();
+        let params = rcgen::CertificateParams::new(vec!["tentacle.invalid".to_string()]).unwrap();
+        params.self_signed(&tls_keypair).unwrap().der().to_vec()
+    }
+
+    /// Molecule-encode an identity payload with arbitrary field values.
+    ///
+    /// `peer_id` must be exactly 34 bytes (the fixed multihash length).
+    fn encode_identity(
+        version: u8,
+        secio_pubkey: &[u8],
+        peer_id: &[u8],
+        binding_sig: &[u8],
+    ) -> Vec<u8> {
+        let v = Uint8::new_builder().nth0(version).build();
+        let sp = MolBytes::new_builder()
+            .extend(secio_pubkey.iter().copied().map(Into::into))
+            .build();
+        let pid_array: [u8; 34] = peer_id
+            .try_into()
+            .expect("peer_id must be 34 bytes for the molecule PeerId array");
+        let pid = MolPeerId::from(pid_array);
+        let sig = MolBytes::new_builder()
+            .extend(binding_sig.iter().copied().map(Into::into))
+            .build();
+
+        TentacleQuicIdentityV1::new_builder()
+            .version(v)
+            .secio_pubkey(sp)
+            .peer_id(pid)
+            .binding_sig(sig)
+            .build()
+            .as_bytes()
+            .to_vec()
+    }
+
+    // ──────────────────────── server-side verifier ────────────────────────
+
+    #[test]
+    fn test_server_verify_ok() {
+        let key = SecioKeyPair::secp256k1_generated();
+        let cert = build_self_signed(&key).unwrap();
+        let verifier = TentacleQuicServerCertVerifier::new(key, None);
+        let cert_der = CertificateDer::from(cert.cert_der);
+
+        verifier
+            .verify_server_cert(&cert_der, &[], &valid_server_name(), &[], now())
+            .expect("valid cert should pass");
+    }
+
+    #[test]
+    fn test_server_verify_expired_cert() {
+        let key = SecioKeyPair::secp256k1_generated();
+        let cert = build_self_signed(&key).unwrap();
+        let verifier = TentacleQuicServerCertVerifier::new(key, None);
+        let cert_der = CertificateDer::from(cert.cert_der);
+
+        // rcgen defaults not_after = year 4096. 1<<56 seconds ≈ year 2_283_970.
+        let far_future = UnixTime::since_unix_epoch(Duration::from_secs(1u64 << 56));
+        let result =
+            verifier.verify_server_cert(&cert_der, &[], &valid_server_name(), &[], far_future);
+        assert!(
+            result.is_err(),
+            "cert valid past its not_after should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_server_verify_future_cert() {
+        let key = SecioKeyPair::secp256k1_generated();
+        let cert = build_self_signed(&key).unwrap();
+        let verifier = TentacleQuicServerCertVerifier::new(key, None);
+        let cert_der = CertificateDer::from(cert.cert_der);
+
+        // rcgen defaults not_before = 1975. Epoch (1970) is before that.
+        let too_early = UnixTime::since_unix_epoch(Duration::from_secs(0));
+        let result =
+            verifier.verify_server_cert(&cert_der, &[], &valid_server_name(), &[], too_early);
+        assert!(
+            result.is_err(),
+            "cert valid before its not_before should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_server_verify_with_intermediate() {
+        let key = SecioKeyPair::secp256k1_generated();
+        let cert = build_self_signed(&key).unwrap();
+        let verifier = TentacleQuicServerCertVerifier::new(key, None);
+        let leaf = CertificateDer::from(cert.cert_der.clone());
+        let intermediates = [CertificateDer::from(cert.cert_der)];
+
+        let result =
+            verifier.verify_server_cert(&leaf, &intermediates, &valid_server_name(), &[], now());
+        assert!(
+            result.is_err(),
+            "any non-empty intermediate list must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_server_verify_missing_extension() {
+        let key = SecioKeyPair::secp256k1_generated();
+        let cert_bytes = build_cert_without_extension();
+        let verifier = TentacleQuicServerCertVerifier::new(key, None);
+        let cert_der = CertificateDer::from(cert_bytes);
+
+        let result = verifier.verify_server_cert(&cert_der, &[], &valid_server_name(), &[], now());
+        assert!(
+            result.is_err(),
+            "cert without tentacle extension must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_server_verify_wrong_version() {
+        let key = SecioKeyPair::secp256k1_generated();
+        let pubkey = key.public_key().inner_ref().to_vec();
+        let peer_id = key.public_key().peer_id().into_bytes();
+
+        let payload = encode_identity(2, &pubkey, &peer_id, &[0u8; 64]);
+        let cert_bytes = build_cert_with_payload(payload);
+
+        let verifier = TentacleQuicServerCertVerifier::new(key, None);
+        let cert_der = CertificateDer::from(cert_bytes);
+
+        let result = verifier.verify_server_cert(&cert_der, &[], &valid_server_name(), &[], now());
+        assert!(result.is_err(), "version != 1 must be rejected");
+    }
+
+    #[test]
+    fn test_server_verify_binding_sig_invalid() {
+        let key = SecioKeyPair::secp256k1_generated();
+        let pubkey = key.public_key().inner_ref().to_vec();
+        let peer_id = key.public_key().peer_id().into_bytes();
+
+        // A syntactically reasonable but semantically wrong signature.
+        let bogus_sig = vec![0xab; 64];
+        let payload = encode_identity(IDENTITY_VERSION, &pubkey, &peer_id, &bogus_sig);
+        let cert_bytes = build_cert_with_payload(payload);
+
+        let verifier = TentacleQuicServerCertVerifier::new(key, None);
+        let cert_der = CertificateDer::from(cert_bytes);
+
+        let result = verifier.verify_server_cert(&cert_der, &[], &valid_server_name(), &[], now());
+        assert!(result.is_err(), "invalid binding_sig must be rejected");
+    }
+
+    #[test]
+    fn test_server_verify_expected_peer_id_mismatch() {
+        let key = SecioKeyPair::secp256k1_generated();
+        let cert = build_self_signed(&key).unwrap();
+
+        // Expect a different peer than the one the cert actually binds to.
+        let wrong_expected = SecioKeyPair::secp256k1_generated().public_key().peer_id();
+        let verifier = TentacleQuicServerCertVerifier::new(key, Some(wrong_expected));
+        let cert_der = CertificateDer::from(cert.cert_der);
+
+        let result = verifier.verify_server_cert(&cert_der, &[], &valid_server_name(), &[], now());
+        assert!(
+            result.is_err(),
+            "dial target peer_id mismatch must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_server_verify_expected_peer_id_match() {
+        let key = SecioKeyPair::secp256k1_generated();
+        let cert = build_self_signed(&key).unwrap();
+        let correct_peer_id = key.public_key().peer_id();
+
+        let verifier = TentacleQuicServerCertVerifier::new(key, Some(correct_peer_id));
+        let cert_der = CertificateDer::from(cert.cert_der);
+
+        verifier
+            .verify_server_cert(&cert_der, &[], &valid_server_name(), &[], now())
+            .expect("correct expected peer_id should pass");
+    }
+
+    // ──────────────────────── client-side verifier ────────────────────────
+
+    #[test]
+    fn test_client_verify_ok() {
+        let key = SecioKeyPair::secp256k1_generated();
+        let cert = build_self_signed(&key).unwrap();
+        let verifier = TentacleQuicClientCertVerifier::new(key);
+        let cert_der = CertificateDer::from(cert.cert_der);
+
+        verifier
+            .verify_client_cert(&cert_der, &[], now())
+            .expect("valid client cert should pass");
+    }
+
+    #[test]
+    fn test_client_verify_rejects_intermediate() {
+        let key = SecioKeyPair::secp256k1_generated();
+        let cert = build_self_signed(&key).unwrap();
+        let verifier = TentacleQuicClientCertVerifier::new(key);
+        let leaf = CertificateDer::from(cert.cert_der.clone());
+        let intermediates = [CertificateDer::from(cert.cert_der)];
+
+        let result = verifier.verify_client_cert(&leaf, &intermediates, now());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_client_verify_mandatory() {
+        let key = SecioKeyPair::secp256k1_generated();
+        let verifier = TentacleQuicClientCertVerifier::new(key);
+
+        assert!(
+            verifier.client_auth_mandatory(),
+            "client auth must be mandatory"
+        );
+        assert!(verifier.offer_client_auth());
+        assert!(
+            verifier.root_hint_subjects().is_empty(),
+            "tentacle does not surface CA hints"
+        );
+    }
+}

--- a/tentacle/tests/test_quic_verifier.rs
+++ b/tentacle/tests/test_quic_verifier.rs
@@ -76,27 +76,38 @@ fn spawn_quinn_server(rustls_cfg: ServerConfig) -> (quinn::Endpoint, std::net::S
 }
 
 /// Stand up a quinn client and start connecting to `server_addr`.
+///
+/// Returns both the `Endpoint` and the `Connecting`. The caller MUST keep the
+/// `Endpoint` alive until the handshake completes — quinn's `Connecting` does
+/// not hold a clone of the `Endpoint`, so dropping the last `Endpoint` clone
+/// terminates the `EndpointDriver` that routes inbound UDP datagrams, which
+/// would silently break the handshake (or just make the test flaky).
 fn connect_quinn_client(
     rustls_cfg: ClientConfig,
     server_addr: std::net::SocketAddr,
-) -> quinn::Connecting {
+) -> (quinn::Endpoint, quinn::Connecting) {
     let quinn_cfg =
         quinn::ClientConfig::new(Arc::new(QuicClientConfig::try_from(rustls_cfg).unwrap()));
     let endpoint = quinn::Endpoint::client("0.0.0.0:0".parse().unwrap()).unwrap();
-    endpoint
+    let connecting = endpoint
         .connect_with(quinn_cfg, server_addr, "tentacle.invalid")
-        .expect("connect_with")
+        .expect("connect_with");
+    (endpoint, connecting)
 }
 
-/// Pull the peer certificate chain from a quinn connection and decode the
-/// tentacle identity extension from its leaf certificate.
+/// Pull the peer certificate chain from a quinn connection and derive the
+/// peer's `PeerId` the same way the verifier does — from the `secio_pubkey`
+/// field of the tentacle identity extension. The `PeerId` is **not** stored
+/// in the extension; it is a deterministic derivation.
 fn peer_identity_peer_id_bytes(conn: &quinn::Connection) -> Vec<u8> {
     let any = conn.peer_identity().expect("peer_identity present");
     let chain = any
         .downcast::<Vec<CertificateDer<'static>>>()
         .expect("cert chain downcast");
     let identity = extract_identity(chain[0].as_ref()).expect("extract identity");
-    identity.peer_id().raw_data().as_ref().to_vec()
+    let secio_pubkey =
+        tentacle::secio::PublicKey::from_raw_key(identity.secio_pubkey().raw_data().to_vec());
+    secio_pubkey.peer_id().into_bytes()
 }
 
 // ────────────────────────── end-to-end test cases ──────────────────────────
@@ -127,11 +138,11 @@ async fn e2e_handshake_succeeds_with_tentacle_identities() {
         observed
     });
 
-    // Client connects with the expected server PeerId pinned.
+    // Client connects with the expected server PeerId pinned. We bind the
+    // endpoint to a local so it stays alive for the lifetime of the handshake.
     let rustls_client = tentacle_client_config(client_key, client_cert, Some(server_peer_id));
-    let client_conn = connect_quinn_client(rustls_client, server_addr)
-        .await
-        .expect("client handshake ok");
+    let (_client_endpoint, client_connecting) = connect_quinn_client(rustls_client, server_addr);
+    let client_conn = client_connecting.await.expect("client handshake ok");
 
     // Client sees the server's PeerId in the presented cert.
     let observed_server = peer_identity_peer_id_bytes(&client_conn);
@@ -175,7 +186,8 @@ async fn e2e_handshake_fails_when_client_has_no_extension() {
         )
         .expect("client rustls config");
 
-    let client_result = connect_quinn_client(rustls_client, server_addr).await;
+    let (_client_endpoint, client_connecting) = connect_quinn_client(rustls_client, server_addr);
+    let client_result = client_connecting.await;
     let server_result = server_task.await.expect("server join");
 
     // Either side may surface the failure first; we only require that the

--- a/tentacle/tests/test_quic_verifier.rs
+++ b/tentacle/tests/test_quic_verifier.rs
@@ -1,0 +1,190 @@
+//! End-to-end integration tests for the Tentacle QUIC verifiers.
+//!
+//! These tests spin up a real `quinn` server and client over loopback,
+//! plug in [`TentacleQuicServerCertVerifier`] / [`TentacleQuicClientCertVerifier`],
+//! and verify that:
+//!
+//! - a positive handshake works when both sides present a tentacle-bound
+//!   certificate built by [`build_self_signed`], and each peer can recover
+//!   the counterpart's `PeerId` via [`extract_identity`];
+//! - a negative handshake is rejected when the client presents a plain
+//!   self-signed Ed25519 certificate without the tentacle private extension.
+//!
+//! Unit tests for the verifier logic itself live next to the implementation
+//! in `src/quic/verifier.rs`.
+
+#![cfg(feature = "quic")]
+
+use std::sync::Arc;
+
+use quinn::crypto::rustls::{QuicClientConfig, QuicServerConfig};
+use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer};
+use rustls::{ClientConfig, ServerConfig};
+
+use tentacle::quic::identity::{TentacleQuicCert, build_self_signed, extract_identity};
+use tentacle::quic::verifier::{TentacleQuicClientCertVerifier, TentacleQuicServerCertVerifier};
+use tentacle::secio::SecioKeyPair;
+
+// ───────────────────────────────── helpers ─────────────────────────────────
+
+/// Build a `rustls::ServerConfig` that authenticates clients via
+/// [`TentacleQuicClientCertVerifier`] and presents `cert` as its own identity.
+fn tentacle_server_config(key: SecioKeyPair, cert: TentacleQuicCert) -> ServerConfig {
+    let cert_der = CertificateDer::from(cert.cert_der);
+    let key_der = PrivatePkcs8KeyDer::from(cert.key_der);
+    ServerConfig::builder()
+        .with_client_cert_verifier(Arc::new(TentacleQuicClientCertVerifier::new(key)))
+        .with_single_cert(vec![cert_der], key_der.into())
+        .expect("server rustls config")
+}
+
+/// Build a `rustls::ClientConfig` that verifies the server via
+/// [`TentacleQuicServerCertVerifier`] and presents `cert` as its own identity.
+fn tentacle_client_config(
+    key: SecioKeyPair,
+    cert: TentacleQuicCert,
+    expected_peer_id: Option<tentacle::secio::PeerId>,
+) -> ClientConfig {
+    let cert_der = CertificateDer::from(cert.cert_der);
+    let key_der = PrivatePkcs8KeyDer::from(cert.key_der);
+    ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(TentacleQuicServerCertVerifier::new(
+            key,
+            expected_peer_id,
+        )))
+        .with_client_auth_cert(vec![cert_der], key_der.into())
+        .expect("client rustls config")
+}
+
+/// Plain Ed25519 self-signed cert/key with NO tentacle extension. Used to
+/// exercise the negative path.
+fn build_plain_cert_and_key() -> (Vec<u8>, Vec<u8>) {
+    let tls_keypair = rcgen::KeyPair::generate_for(&rcgen::PKCS_ED25519).unwrap();
+    let params = rcgen::CertificateParams::new(vec!["tentacle.invalid".to_string()]).unwrap();
+    let cert = params.self_signed(&tls_keypair).unwrap();
+    (cert.der().to_vec(), tls_keypair.serialize_der())
+}
+
+/// Stand up a quinn server endpoint configured with the given rustls config.
+fn spawn_quinn_server(rustls_cfg: ServerConfig) -> (quinn::Endpoint, std::net::SocketAddr) {
+    let quinn_cfg =
+        quinn::ServerConfig::with_crypto(Arc::new(QuicServerConfig::try_from(rustls_cfg).unwrap()));
+    let endpoint = quinn::Endpoint::server(quinn_cfg, "127.0.0.1:0".parse().unwrap()).unwrap();
+    let addr = endpoint.local_addr().unwrap();
+    (endpoint, addr)
+}
+
+/// Stand up a quinn client and start connecting to `server_addr`.
+fn connect_quinn_client(
+    rustls_cfg: ClientConfig,
+    server_addr: std::net::SocketAddr,
+) -> quinn::Connecting {
+    let quinn_cfg =
+        quinn::ClientConfig::new(Arc::new(QuicClientConfig::try_from(rustls_cfg).unwrap()));
+    let endpoint = quinn::Endpoint::client("0.0.0.0:0".parse().unwrap()).unwrap();
+    endpoint
+        .connect_with(quinn_cfg, server_addr, "tentacle.invalid")
+        .expect("connect_with")
+}
+
+/// Pull the peer certificate chain from a quinn connection and decode the
+/// tentacle identity extension from its leaf certificate.
+fn peer_identity_peer_id_bytes(conn: &quinn::Connection) -> Vec<u8> {
+    let any = conn.peer_identity().expect("peer_identity present");
+    let chain = any
+        .downcast::<Vec<CertificateDer<'static>>>()
+        .expect("cert chain downcast");
+    let identity = extract_identity(chain[0].as_ref()).expect("extract identity");
+    identity.peer_id().raw_data().as_ref().to_vec()
+}
+
+// ────────────────────────── end-to-end test cases ──────────────────────────
+
+/// Both sides carry valid tentacle certs → TLS handshake succeeds and each
+/// peer can recover the other's `PeerId` from the presented certificate.
+#[tokio::test]
+async fn e2e_handshake_succeeds_with_tentacle_identities() {
+    let server_key = SecioKeyPair::secp256k1_generated();
+    let server_cert = build_self_signed(&server_key).unwrap();
+    let server_peer_id = server_key.public_key().peer_id();
+    let server_peer_id_bytes = server_peer_id.clone().into_bytes();
+
+    let client_key = SecioKeyPair::secp256k1_generated();
+    let client_cert = build_self_signed(&client_key).unwrap();
+    let client_peer_id_bytes = client_key.public_key().peer_id().into_bytes();
+
+    let rustls_server = tentacle_server_config(server_key.clone(), server_cert);
+    let (server_endpoint, server_addr) = spawn_quinn_server(rustls_server);
+
+    // Server task: accept the connection and report the client's PeerId.
+    let server_task = tokio::spawn(async move {
+        let incoming = server_endpoint.accept().await.expect("incoming");
+        let conn = incoming.await.expect("server handshake ok");
+        let observed = peer_identity_peer_id_bytes(&conn);
+        // Keep the connection alive until the client closes it.
+        conn.closed().await;
+        observed
+    });
+
+    // Client connects with the expected server PeerId pinned.
+    let rustls_client = tentacle_client_config(client_key, client_cert, Some(server_peer_id));
+    let client_conn = connect_quinn_client(rustls_client, server_addr)
+        .await
+        .expect("client handshake ok");
+
+    // Client sees the server's PeerId in the presented cert.
+    let observed_server = peer_identity_peer_id_bytes(&client_conn);
+    assert_eq!(observed_server, server_peer_id_bytes);
+
+    // Close the client side and let the server task observe the client cert.
+    client_conn.close(0u32.into(), b"done");
+
+    let observed_client = server_task.await.expect("server join");
+    assert_eq!(observed_client, client_peer_id_bytes);
+}
+
+/// Client presents a plain Ed25519 cert with no tentacle extension. The
+/// server's [`TentacleQuicClientCertVerifier`] must reject the handshake.
+#[tokio::test]
+async fn e2e_handshake_fails_when_client_has_no_extension() {
+    let server_key = SecioKeyPair::secp256k1_generated();
+    let server_cert = build_self_signed(&server_key).unwrap();
+
+    let rustls_server = tentacle_server_config(server_key, server_cert);
+    let (server_endpoint, server_addr) = spawn_quinn_server(rustls_server);
+
+    let server_task = tokio::spawn(async move {
+        let incoming = server_endpoint.accept().await.expect("incoming");
+        // Expected to fail at handshake time.
+        incoming.await
+    });
+
+    // Client presents a plain Ed25519 cert — no tentacle extension.
+    let (plain_cert, plain_key) = build_plain_cert_and_key();
+    let local_key = SecioKeyPair::secp256k1_generated();
+
+    let rustls_client = ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(TentacleQuicServerCertVerifier::new(
+            local_key, None,
+        )))
+        .with_client_auth_cert(
+            vec![CertificateDer::from(plain_cert)],
+            PrivatePkcs8KeyDer::from(plain_key).into(),
+        )
+        .expect("client rustls config");
+
+    let client_result = connect_quinn_client(rustls_client, server_addr).await;
+    let server_result = server_task.await.expect("server join");
+
+    // Either side may surface the failure first; we only require that the
+    // handshake does NOT succeed end-to-end.
+    assert!(
+        client_result.is_err() || server_result.is_err(),
+        "handshake must fail when client lacks tentacle identity extension; \
+         client_result = {:?}, server_result_ok = {}",
+        client_result.as_ref().err(),
+        server_result.is_ok(),
+    );
+}


### PR DESCRIPTION
## Summary

This PR is **part 3 of 5** in the series to add native QUIC transport support to Tentacle, as outlined in [#428](https://github.com/nervosnetwork/tentacle/issues/428).

### QUIC Implementation Roadmap

| PR | Title | Description |
|----|-------|-------------|
| PR 1 | multiaddr: add `Udp` and `QuicV1` protocols | Extend the multiaddr crate to parse, serialize, and display `/udp/<port>` and `/quic-v1` protocol components |
| PR 2 | QUIC connectivity spike + self-signed certificate generation | Introduce the `quic` feature with `quinn`/`rustls`/`rcgen`/`x509-parser`/`ring` dependencies; implement the dual-key model with a self-signed X.509 certificate carrying a molecule-encoded private extension and `binding_sig` |
| **PR 3 (this)** | Custom rustls certificate verifiers | Implement `TentacleQuicServerCertVerifier` and `TentacleQuicClientCertVerifier` that bypass the CA / hostname model and enforce the Tentacle identity binding model end-to-end through the rustls handshake path |
| PR 4 | End-to-end QuicSession | Wire up `QuicBiStream`, `QuicEndpoint`, `QuicSession`, and the three integration points into `InnerService`; generalize `Substream<U>` with a stream type parameter |
| PR 5 | ServiceBuilder integration, example, and docs | Expose `ServiceBuilder::quic_config()`, add a runnable example, and write user-facing documentation |

### What this PR does

**1. New `tentacle/src/quic/verifier.rs`** — two `rustls` verifiers parameterised by `K: KeyProvider`:

- `TentacleQuicServerCertVerifier<K>` — implements `rustls::client::danger::ServerCertVerifier`. Used by the **client side** of a QUIC connection to validate the server's certificate. Holds an optional `expected_peer_id` extracted from the dial target's `/p2p/<peer_id>` suffix.
- `TentacleQuicClientCertVerifier<K>` — implements `rustls::server::danger::ClientCertVerifier`. Used by the **server side** to validate the client's certificate. Forces `client_auth_mandatory() == true` so plain TLS clients cannot connect.

Both verifiers share `verify_tentacle_cert`, which enforces the following on the presented leaf:

1. The chain contains **exactly one** leaf certificate (no intermediates).
2. The leaf's `notBefore` / `notAfter` covers `now`.
3. Locate exactly one X.509 extension whose OID equals `TENTACLE_QUIC_IDENT_OID`; molecule-decode it as `TentacleQuicIdentityV1` with `version == 1` (delegated to `extract_identity` from PR 2).
4. Verify the secp256k1 `binding_sig` against `sha256(BINDING_DOMAIN || leaf_spki_der)` using `secio_pubkey` from the extension (delegated to `verify_binding`).
5. (Client only) If `expected_peer_id` is `Some`, it must equal `PeerId::from_public_key(secio_pubkey)`.

The `peer_id` field stored in the extension is **not** checked against `secio_pubkey` — it is a deterministic derivation, so verifying it adds no security value. The verifier always derives `PeerId` from `secio_pubkey` directly.

SAN and hostname are intentionally never checked. Per-message TLS handshake signatures (`verify_tls12_signature` / `verify_tls13_signature`) and the advertised signature scheme list are delegated to the rustls `aws_lc_rs` default crypto provider, matching what the `tls` feature already pulls in.

**2. Verifier types are `pub`**, not `pub(crate)`. PR 4 / PR 5 will need them from the `endpoint` and `ServiceBuilder` paths, and the integration test in `tests/` (see below) needs them as well.

**3. New `tentacle/tests/test_quic_verifier.rs`** — end-to-end integration tests gated behind `[[test]] required-features = ["quic"]`. Uses real `quinn::Endpoint`s over loopback to exercise the full TLS handshake path with our verifiers.

**4. `tentacle/src/quic/mod.rs`** — declares `pub mod verifier;`.

**5. `tentacle/Cargo.toml`** — adds the `[[test]]` entry so `cargo test --no-default-features` skips the integration test cleanly.

### Design notes

- **Why `pub` not `pub(crate)`?** Plan §5.8 originally targeted `pub(crate)`. We promoted them to `pub` because (a) PR 4's `QuicEndpoint` and PR 5's `ServiceBuilder` need them, and (b) the integration tests live in `tests/` (a separate crate) and cannot reach `pub(crate)` items. The visibility may be revisited in PR 5 once the public API surface stabilises.
- **Why parameterise on `K: KeyProvider`?** `verify_binding` uses `KeyProvider::verify_ecdsa` to dispatch the secp256k1 check (the trait method does not actually touch the private key — see [secio/src/lib.rs:167](secio/src/lib.rs#L167)). Holding `K` lets callers thread their existing service `KeyProvider` through without introducing a parallel "verifier-only" trait.
- **Why default to `aws_lc_rs`?** PR 2 aligned the QUIC stack on `aws_lc_rs` so the `tls` feature (which transitively brings in `rustls/aws_lc_rs` via `tokio-rustls`) and the `quic` feature do not enable two competing crypto providers in the same `rustls` build. PR 3 inherits that choice — `crypto_provider` is `rustls::crypto::aws_lc_rs::default_provider()` by default.

## Test plan

**13 unit tests** in `tentacle/src/quic/verifier.rs`:

Server-side (10 tests):
- [x] `test_server_verify_ok` — happy path with a freshly built cert
- [x] `test_server_verify_expired_cert` — `now` past `notAfter` (4096) → rejected
- [x] `test_server_verify_future_cert` — `now == 1970` (before `notBefore == 1975`) → rejected
- [x] `test_server_verify_with_intermediate` — non-empty intermediate list → rejected
- [x] `test_server_verify_missing_extension` — cert without the tentacle OID → `ExtensionNotFound`
- [x] `test_server_verify_wrong_version` — extension with `version == 2` → `IdentityVersionUnsupported(2)`
- [x] `test_server_verify_peer_id_mismatch_in_ext` — `peer_id` field tampered (still rejected because the bogus payload's `binding_sig` is invalid for the cert's SPKI)
- [x] `test_server_verify_binding_sig_invalid` — well-formed payload with `binding_sig = [0xab; 64]` → `SigningError`
- [x] `test_server_verify_expected_peer_id_mismatch` — `expected_peer_id = Some(other)` → rejected
- [x] `test_server_verify_expected_peer_id_match` — `expected_peer_id = Some(correct)` → passes

Client-side (3 tests):
- [x] `test_client_verify_ok` — happy path
- [x] `test_client_verify_rejects_intermediate` — non-empty intermediate list → rejected
- [x] `test_client_verify_mandatory` — `client_auth_mandatory() == true`, `offer_client_auth() == true`, `root_hint_subjects().is_empty()`

**2 end-to-end integration tests** in `tentacle/tests/test_quic_verifier.rs`:

- [x] `e2e_handshake_succeeds_with_tentacle_identities` — both peers present valid tentacle certs, the TLS handshake completes, and **each side recovers the other's `PeerId` from `quinn::Connection::peer_identity()`**. Exercises mTLS in both directions, the `expected_peer_id` pin, and the full quinn + rustls + verifier stack.
- [x] `e2e_handshake_fails_when_client_has_no_extension` — server has a valid tentacle cert; client presents a plain self-signed Ed25519 cert. Server's `TentacleQuicClientCertVerifier` rejects the handshake; the connection never establishes.

**Regression checks**:

- [x] `cargo test --features quic -p tentacle --lib quic` — all 22 unit tests pass (PR 2's 9 identity tests + PR 3's 13 verifier tests)
- [x] `cargo test --features quic -p tentacle --test test_quic_verifier` — both integration tests pass
- [x] `cargo test --all --features ws,unstable,tls,upnp` (matches CI; implicitly enables `quic` via defaults) — full workspace passes, no rustls crypto-provider conflict
- [x] `cargo test --all --no-default-features --features tokio-runtime,tokio-timer` — `quic` opt-out still compiles cleanly; the integration test is skipped via `required-features`
