### PR TITLE
fix: Avoid unaligned integer reads in protocol decoders

### DIFF
--- a/protocols/discovery/src/protocol.rs
+++ b/protocols/discovery/src/protocol.rs
@@ -122,19 +122,18 @@ impl DiscoveryMessage {
             .as_bytes()
     }
 
-    #[allow(clippy::cast_ptr_alignment)]
     pub fn decode(data: &[u8]) -> Option<Self> {
         let reader = protocol_mol::DiscoveryMessageReader::from_compatible_slice(data).ok()?;
         match reader.payload().to_enum() {
             protocol_mol::DiscoveryPayloadUnionReader::GetNodes(reader) => {
-                let le = reader.version().raw_data().as_ptr() as *const u32;
-                let version = u32::from_le(unsafe { *le });
-                let le = reader.count().raw_data().as_ptr() as *const u32;
-                let count = u32::from_le(unsafe { *le });
-                let listen_port = reader.listen_port().to_opt().map(|port_reader| {
-                    let le = port_reader.raw_data().as_ptr() as *const u16;
-                    u16::from_le(unsafe { *le })
-                });
+                let version = u32::from_le_bytes(reader.version().raw_data().try_into().ok()?);
+                let count = u32::from_le_bytes(reader.count().raw_data().try_into().ok()?);
+                let listen_port = match reader.listen_port().to_opt() {
+                    Some(port_reader) => {
+                        Some(u16::from_le_bytes(port_reader.raw_data().try_into().ok()?))
+                    }
+                    None => None,
+                };
                 Some(DiscoveryMessage::GetNodes {
                     version,
                     count,

--- a/protocols/ping/src/lib.rs
+++ b/protocols/ping/src/lib.rs
@@ -286,17 +286,16 @@ impl PingMessage {
             .as_bytes()
     }
 
-    #[allow(clippy::cast_ptr_alignment)]
     fn decode(data: &[u8]) -> Option<PingPayload> {
         let reader = protocol_mol::PingMessageReader::from_compatible_slice(data).ok()?;
         match reader.payload().to_enum() {
             protocol_mol::PingPayloadUnionReader::Ping(reader) => {
-                let le = reader.nonce().raw_data().as_ptr() as *const u32;
-                Some(PingPayload::Ping(u32::from_le(unsafe { *le })))
+                let nonce = u32::from_le_bytes(reader.nonce().raw_data().try_into().ok()?);
+                Some(PingPayload::Ping(nonce))
             }
             protocol_mol::PingPayloadUnionReader::Pong(reader) => {
-                let le = reader.nonce().raw_data().as_ptr() as *const u32;
-                Some(PingPayload::Pong(u32::from_le(unsafe { *le })))
+                let nonce = u32::from_le_bytes(reader.nonce().raw_data().try_into().ok()?);
+                Some(PingPayload::Pong(nonce))
             }
         }
     }


### PR DESCRIPTION
## Summary

This removes alignment-unsafe integer parsing from the ping and discovery Molecule decoders.

The previous code cast raw Molecule byte slices to `*const u32` / `*const u16` and dereferenced them directly. Network input is not guaranteed to be aligned for those typed loads, so this can cause undefined behavior or crashes on strict-alignment targets.

## Changes

- Decode ping nonce values with `u32::from_le_bytes`.
- Decode discovery `version`, `count`, and `listen_port` values with `from_le_bytes`.
- Remove the now-unneeded `cast_ptr_alignment` allowances.
