### PR TITLE
fix: Avoid logging derived secio key material

### DIFF
--- a/secio/src/handshake/procedure.rs
+++ b/secio/src/handshake/procedure.rs
@@ -202,10 +202,7 @@ where
         }
     };
 
-    trace!(
-        "local info: {:?}, remote_info: {:?}",
-        local_infos, remote_infos
-    );
+    trace!("derived local and remote secio key material");
 
     let encode_cipher = generate_stream_cipher_and_hmac(
         chosen_cipher,


### PR DESCRIPTION
## Summary

Remove trace-level logging of derived secio key material during handshake.

The previous log message printed `local_infos` and `remote_infos`, which are derived from the shared secret and then used to build the stream cipher state. Even though this was only emitted at trace level, logs should not include key material.

## Changes

- Replace the trace log containing raw `local_infos` / `remote_infos` bytes with a non-sensitive message.

## Testing

```text
cargo fmt -p tentacle-secio
cargo test -p tentacle-secio
```