### PR TITLE
fix: Propagate substream write backpressure

### DIFF
--- a/tentacle/src/channel/bound.rs
+++ b/tentacle/src/channel/bound.rs
@@ -591,6 +591,32 @@ impl<T> Receiver<T> {
         }
     }
 
+    /// Tries to receive the next high-priority message without draining the
+    /// normal-priority queue.
+    pub(crate) fn try_next_high(&mut self) -> Result<Option<T>, TryRecvError> {
+        let inner = self
+            .inner
+            .as_mut()
+            .expect("Receiver::try_next_high called after `None`");
+
+        match unsafe { inner.quick_message_queue.pop_spin() } {
+            Some(msg) => {
+                self.unpark_one();
+                self.dec_num_messages();
+                Ok(Some(msg))
+            }
+            None => {
+                let state = decode_state(inner.state.load(SeqCst));
+                if state.is_closed() {
+                    self.inner = None;
+                    Ok(None)
+                } else {
+                    Err(TryRecvError { _priv: () })
+                }
+            }
+        }
+    }
+
     fn next_message(&mut self) -> Poll<Option<(Priority, T)>> {
         let inner = self
             .inner

--- a/tentacle/src/substream.rs
+++ b/tentacle/src/substream.rs
@@ -199,22 +199,24 @@ where
     }
 
     /// Send data to the lower `yamux` sub stream
-    fn send_data(&mut self, cx: &mut Context) -> Result<(), io::Error> {
+    fn send_data(&mut self, cx: &mut Context) -> Result<bool, io::Error> {
         while let Some(frame) = self.high_write_buf.pop_front() {
             if self.send_inner(cx, frame, Priority::High)? {
-                return Ok(());
+                return Ok(true);
             }
         }
 
         while let Some(frame) = self.write_buf.pop_front() {
             if self.send_inner(cx, frame, Priority::Normal)? {
-                return Ok(());
+                return Ok(true);
             }
         }
 
-        self.poll_complete(cx)?;
+        self.poll_complete(cx)
+    }
 
-        Ok(())
+    fn has_write_backpressure(&self) -> bool {
+        self.high_write_buf.len() + self.write_buf.len() > self.config.send_event_size()
     }
 
     /// https://docs.rs/tokio/0.1.19/tokio/prelude/trait.Sink.html
@@ -303,27 +305,35 @@ where
     }
 
     /// Handling commands send by session
-    fn handle_proto_event(&mut self, cx: &mut Context, event: ProtocolEvent, priority: Priority) {
+    fn handle_proto_event(
+        &mut self,
+        cx: &mut Context,
+        event: ProtocolEvent,
+        priority: Priority,
+    ) -> bool {
         match event {
             ProtocolEvent::Message { data } => {
                 self.push_back(priority, data);
 
-                if let Err(err) = self.send_data(cx) {
-                    // Whether it is a read send error or a flush error,
-                    // the most essential problem is that there is a problem with the external network.
-                    // Close the protocol stream directly.
-                    debug!(
-                        "protocol [{}] close because of extern network",
-                        self.proto_id
-                    );
-                    self.output_event(
-                        cx,
-                        ProtocolEvent::Error {
-                            proto_id: self.proto_id,
-                            error: err,
-                        },
-                    );
-                    self.dead = true;
+                match self.send_data(cx) {
+                    Ok(is_pending) => return is_pending,
+                    Err(err) => {
+                        // Whether it is a read send error or a flush error,
+                        // the most essential problem is that there is a problem with the external network.
+                        // Close the protocol stream directly.
+                        debug!(
+                            "protocol [{}] close because of extern network",
+                            self.proto_id
+                        );
+                        self.output_event(
+                            cx,
+                            ProtocolEvent::Error {
+                                proto_id: self.proto_id,
+                                error: err,
+                            },
+                        );
+                        self.dead = true;
+                    }
                 }
             }
             ProtocolEvent::Close { .. } => {
@@ -332,6 +342,7 @@ where
             }
             _ => (),
         }
+        false
     }
 
     fn distribute_to_user_level(&mut self, cx: &mut Context) {
@@ -375,14 +386,17 @@ where
             return Poll::Ready(None);
         }
 
-        if self.write_buf.len() > self.config.send_event_size() {
+        if self.has_write_backpressure() {
             return Poll::Pending;
         }
 
         match Pin::new(&mut self.event_receiver).as_mut().poll_next(cx) {
             Poll::Ready(Some((priority, event))) => {
-                self.handle_proto_event(cx, event, priority);
-                Poll::Ready(Some(()))
+                if self.handle_proto_event(cx, event, priority) {
+                    Poll::Pending
+                } else {
+                    Poll::Ready(Some(()))
+                }
             }
             Poll::Ready(None) => {
                 // Must be session close
@@ -460,8 +474,8 @@ where
     }
 
     #[inline]
-    fn flush(&mut self, cx: &mut Context) -> Result<(), io::Error> {
-        self.poll_complete(cx)?;
+    fn flush(&mut self, cx: &mut Context) -> Result<bool, io::Error> {
+        let mut is_pending = self.poll_complete(cx)?;
         if !self
             .service_proto_sender
             .as_ref()
@@ -483,12 +497,11 @@ where
             self.output(cx);
 
             match self.send_data(cx) {
-                Ok(()) => Ok(()),
-                Err(err) => Err(err),
+                Ok(pending) => is_pending |= pending,
+                Err(err) => return Err(err),
             }
-        } else {
-            Ok(())
         }
+        Ok(is_pending)
     }
 }
 
@@ -509,14 +522,17 @@ where
             return Poll::Ready(None);
         }
 
-        if let Err(err) = self.flush(cx) {
-            debug!(
-                "Substream({}) finished with flush error: {:?}",
-                self.id, err
-            );
-            self.error_close(cx, err);
-            return Poll::Ready(None);
-        }
+        let write_pending = match self.flush(cx) {
+            Ok(pending) => pending,
+            Err(err) => {
+                debug!(
+                    "Substream({}) finished with flush error: {:?}",
+                    self.id, err
+                );
+                self.error_close(cx, err);
+                return Poll::Ready(None);
+            }
+        };
 
         debug!(
             "Substream({}) write buf: {}, read buf: {}",
@@ -529,7 +545,11 @@ where
 
         let mut is_pending = self.recv_frame(cx).is_pending();
 
-        is_pending &= self.recv_event(cx).is_pending();
+        is_pending &= if write_pending {
+            true
+        } else {
+            self.recv_event(cx).is_pending()
+        };
 
         if is_pending {
             Poll::Pending
@@ -716,27 +736,29 @@ where
     }
 
     /// Send data to the lower `yamux` sub stream
-    fn send_data(&mut self, cx: &mut Context) -> Result<(), io::Error> {
+    fn send_data(&mut self, cx: &mut Context) -> Result<bool, io::Error> {
         while let Some(frame) = self.high_write_buf.pop_front() {
             if self.send_inner(cx, frame, Priority::High)? {
-                return Ok(());
+                return Ok(true);
             }
         }
 
         while let Some(frame) = self.write_buf.pop_front() {
             if self.send_inner(cx, frame, Priority::Normal)? {
-                return Ok(());
+                return Ok(true);
             }
         }
 
-        self.poll_complete(cx)?;
+        self.poll_complete(cx)
+    }
 
-        Ok(())
+    fn has_write_backpressure(&self) -> bool {
+        self.high_write_buf.len() + self.write_buf.len() > self.config.send_event_size()
     }
 
     #[inline]
-    fn flush(&mut self, cx: &mut Context) -> Result<(), io::Error> {
-        self.poll_complete(cx)?;
+    fn flush(&mut self, cx: &mut Context) -> Result<bool, io::Error> {
+        let mut is_pending = self.poll_complete(cx)?;
         if !self.event_sender.is_empty()
             || !self.write_buf.is_empty()
             || !self.high_write_buf.is_empty()
@@ -744,36 +766,43 @@ where
             self.output(cx);
 
             match self.send_data(cx) {
-                Ok(()) => Ok(()),
-                Err(err) => Err(err),
+                Ok(pending) => is_pending |= pending,
+                Err(err) => return Err(err),
             }
-        } else {
-            Ok(())
         }
+        Ok(is_pending)
     }
 
     /// Handling commands send by session
-    fn handle_proto_event(&mut self, cx: &mut Context, event: ProtocolEvent, priority: Priority) {
+    fn handle_proto_event(
+        &mut self,
+        cx: &mut Context,
+        event: ProtocolEvent,
+        priority: Priority,
+    ) -> bool {
         match event {
             ProtocolEvent::Message { data } => {
                 self.push_back(priority, data);
 
-                if let Err(err) = self.send_data(cx) {
-                    // Whether it is a read send error or a flush error,
-                    // the most essential problem is that there is a problem with the external network.
-                    // Close the protocol stream directly.
-                    debug!(
-                        "protocol [{}] close because of extern network",
-                        self.proto_id
-                    );
-                    self.output_event(
-                        cx,
-                        ProtocolEvent::Error {
-                            proto_id: self.proto_id,
-                            error: err,
-                        },
-                    );
-                    self.dead = true;
+                match self.send_data(cx) {
+                    Ok(is_pending) => return is_pending,
+                    Err(err) => {
+                        // Whether it is a read send error or a flush error,
+                        // the most essential problem is that there is a problem with the external network.
+                        // Close the protocol stream directly.
+                        debug!(
+                            "protocol [{}] close because of extern network",
+                            self.proto_id
+                        );
+                        self.output_event(
+                            cx,
+                            ProtocolEvent::Error {
+                                proto_id: self.proto_id,
+                                error: err,
+                            },
+                        );
+                        self.dead = true;
+                    }
                 }
             }
             ProtocolEvent::Close { .. } => {
@@ -782,6 +811,7 @@ where
             }
             _ => (),
         }
+        false
     }
 
     fn recv_event(&mut self, cx: &mut Context) -> Poll<Option<()>> {
@@ -789,14 +819,17 @@ where
             return Poll::Ready(None);
         }
 
-        if self.write_buf.len() > self.config.send_event_size() {
+        if self.has_write_backpressure() {
             return Poll::Pending;
         }
 
         match Pin::new(&mut self.event_receiver).as_mut().poll_next(cx) {
             Poll::Ready(Some((priority, event))) => {
-                self.handle_proto_event(cx, event, priority);
-                Poll::Ready(Some(()))
+                if self.handle_proto_event(cx, event, priority) {
+                    Poll::Pending
+                } else {
+                    Poll::Ready(Some(()))
+                }
             }
             Poll::Ready(None) => {
                 // Must be session close
@@ -883,14 +916,17 @@ where
             return Poll::Ready(None);
         }
 
-        if let Err(err) = self.flush(cx) {
-            debug!(
-                "Substream({}) finished with flush error: {:?}",
-                self.id, err
-            );
-            self.error_close(cx, err);
-            return Poll::Ready(None);
-        }
+        let write_pending = match self.flush(cx) {
+            Ok(pending) => pending,
+            Err(err) => {
+                debug!(
+                    "Substream({}) finished with flush error: {:?}",
+                    self.id, err
+                );
+                self.error_close(cx, err);
+                return Poll::Ready(None);
+            }
+        };
 
         debug!(
             "Substream({}) write buf: {}, read buf: {}",
@@ -901,7 +937,7 @@ where
 
         futures::ready!(crate::runtime::poll_proceed(cx));
 
-        let is_pending = self.recv_event(cx).is_pending();
+        let is_pending = write_pending || self.recv_event(cx).is_pending();
 
         if is_pending {
             Poll::Pending

--- a/tentacle/src/substream.rs
+++ b/tentacle/src/substream.rs
@@ -17,7 +17,7 @@ use crate::{
     ProtocolId, StreamId,
     buffer::{Buffer, SendResult},
     builder::BeforeReceive,
-    channel::{mpsc as priority_mpsc, mpsc::Priority},
+    channel::{QuickSinkExt, mpsc as priority_mpsc, mpsc::Priority},
     context::SessionContext,
     protocol_handle_stream::{ServiceProtocolEvent, SessionProtocolEvent},
     service::config::SessionConfig,
@@ -133,6 +133,7 @@ pub(crate) struct Substream<U> {
     event_sender: Buffer<ProtocolEvent>,
     /// Receive events from session
     event_receiver: priority_mpsc::Receiver<ProtocolEvent>,
+    pending_event: Option<(Priority, ProtocolEvent)>,
 
     service_proto_sender: Option<Buffer<ServiceProtocolEvent>>,
     session_proto_sender: Option<Buffer<SessionProtocolEvent>>,
@@ -337,6 +338,7 @@ where
                 }
             }
             ProtocolEvent::Close { .. } => {
+                self.high_write_buf.clear();
                 self.write_buf.clear();
                 self.dead = true;
             }
@@ -381,17 +383,33 @@ where
         }
     }
 
-    fn recv_event(&mut self, cx: &mut Context) -> Poll<Option<()>> {
+    fn recv_event(&mut self, cx: &mut Context, allow_data: bool) -> Poll<Option<()>> {
         if self.dead {
             return Poll::Ready(None);
         }
 
-        if self.has_write_backpressure() {
+        if self.has_write_backpressure() && allow_data {
             return Poll::Pending;
         }
 
-        match Pin::new(&mut self.event_receiver).as_mut().poll_next(cx) {
+        let next_event = if let Some(event) = self.pending_event.take() {
+            Poll::Ready(Some(event))
+        } else if allow_data {
+            Pin::new(&mut self.event_receiver).as_mut().poll_next(cx)
+        } else {
+            match self.event_receiver.try_next_high() {
+                Ok(Some(event)) => Poll::Ready(Some((Priority::High, event))),
+                Ok(None) => Poll::Ready(None),
+                Err(_) => Poll::Pending,
+            }
+        };
+
+        match next_event {
             Poll::Ready(Some((priority, event))) => {
+                if !allow_data && matches!(event, ProtocolEvent::Message { .. }) {
+                    self.pending_event = Some((priority, event));
+                    return Poll::Pending;
+                }
                 if self.handle_proto_event(cx, event, priority) {
                     Poll::Pending
                 } else {
@@ -546,9 +564,9 @@ where
         let mut is_pending = self.recv_frame(cx).is_pending();
 
         is_pending &= if write_pending {
-            true
+            self.recv_event(cx, false).is_pending()
         } else {
-            self.recv_event(cx).is_pending()
+            self.recv_event(cx, true).is_pending()
         };
 
         if is_pending {
@@ -651,6 +669,7 @@ impl SubstreamBuilder {
 
             event_sender: Buffer::new(self.event_sender),
             event_receiver: self.event_receiver,
+            pending_event: None,
 
             service_proto_sender: self.service_proto_sender,
             session_proto_sender: self.session_proto_sender,
@@ -678,6 +697,7 @@ pub(crate) struct SubstreamWritePart<U> {
     event_sender: Buffer<ProtocolEvent>,
     /// Receive events from session
     event_receiver: priority_mpsc::Receiver<ProtocolEvent>,
+    pending_event: Option<(Priority, ProtocolEvent)>,
 
     context: Arc<SessionContext>,
 }
@@ -806,6 +826,7 @@ where
                 }
             }
             ProtocolEvent::Close { .. } => {
+                self.high_write_buf.clear();
                 self.write_buf.clear();
                 self.dead = true;
             }
@@ -814,17 +835,33 @@ where
         false
     }
 
-    fn recv_event(&mut self, cx: &mut Context) -> Poll<Option<()>> {
+    fn recv_event(&mut self, cx: &mut Context, allow_data: bool) -> Poll<Option<()>> {
         if self.dead {
             return Poll::Ready(None);
         }
 
-        if self.has_write_backpressure() {
+        if self.has_write_backpressure() && allow_data {
             return Poll::Pending;
         }
 
-        match Pin::new(&mut self.event_receiver).as_mut().poll_next(cx) {
+        let next_event = if let Some(event) = self.pending_event.take() {
+            Poll::Ready(Some(event))
+        } else if allow_data {
+            Pin::new(&mut self.event_receiver).as_mut().poll_next(cx)
+        } else {
+            match self.event_receiver.try_next_high() {
+                Ok(Some(event)) => Poll::Ready(Some((Priority::High, event))),
+                Ok(None) => Poll::Ready(None),
+                Err(_) => Poll::Pending,
+            }
+        };
+
+        match next_event {
             Poll::Ready(Some((priority, event))) => {
+                if !allow_data && matches!(event, ProtocolEvent::Message { .. }) {
+                    self.pending_event = Some((priority, event));
+                    return Poll::Pending;
+                }
                 if self.handle_proto_event(cx, event, priority) {
                     Poll::Pending
                 } else {
@@ -937,7 +974,11 @@ where
 
         futures::ready!(crate::runtime::poll_proceed(cx));
 
-        let is_pending = write_pending || self.recv_event(cx).is_pending();
+        let is_pending = if write_pending {
+            self.recv_event(cx, false).is_pending()
+        } else {
+            self.recv_event(cx, true).is_pending()
+        };
 
         if is_pending {
             Poll::Pending
@@ -975,7 +1016,7 @@ impl Drop for SubstreamReadPart {
         let pid = self.proto_id;
         crate::runtime::spawn(async move {
             let _ignore = sender
-                .send(ProtocolEvent::Close { id, proto_id: pid })
+                .quick_send(ProtocolEvent::Close { id, proto_id: pid })
                 .await;
         });
     }
@@ -1071,6 +1112,98 @@ impl SubstreamWritePartBuilder {
 
             event_sender: Buffer::new(self.event_sender),
             event_receiver: self.event_receiver,
+            pending_event: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::SessionId;
+    use crate::service::SessionType;
+    use bytes::Bytes;
+    use futures::task::noop_waker_ref;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicUsize},
+    };
+    use yamux::{
+        Config as YamuxConfig, Session as YamuxSession, session::SessionType as YamuxSessionType,
+    };
+
+    fn session_context() -> Arc<SessionContext> {
+        Arc::new(SessionContext::new(
+            SessionId(1),
+            "/ip4/127.0.0.1/tcp/1337".parse().unwrap(),
+            SessionType::Outbound,
+            None,
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(AtomicUsize::new(0)),
+        ))
+    }
+
+    #[test]
+    fn write_pending_still_handles_high_priority_close() {
+        let (raw, _peer) = tokio::io::duplex(64);
+        let mut config = YamuxConfig::default();
+        config.enable_keepalive = false;
+        let mut yamux = YamuxSession::new(raw, config, YamuxSessionType::Client);
+        let stream = yamux.open_stream().unwrap();
+        let substream = Framed::new(SubstreamInner::Yamux(stream), LengthDelimitedCodec::new());
+        let (sink, _read) = substream.split();
+
+        let (session_event_tx, _session_event_rx) = mpsc::channel(16);
+        let (proto_event_tx, proto_event_rx) = priority_mpsc::channel(16);
+        let context = session_context();
+        let mut write_part =
+            SubstreamWritePartBuilder::new(session_event_tx, proto_event_rx, context.clone())
+                .build(sink);
+
+        let frame = Bytes::from(vec![
+            7;
+            yamux::config::INITIAL_STREAM_WINDOW as usize + 1024
+        ]);
+        context.incr_pending_data_size(frame.len());
+        write_part.write_buf.push_back(frame);
+
+        let waker = noop_waker_ref();
+        let mut cx = Context::from_waker(waker);
+        assert!(Pin::new(&mut write_part).poll_next(&mut cx).is_pending());
+
+        proto_event_tx
+            .try_quick_send(ProtocolEvent::Close {
+                id: write_part.id,
+                proto_id: write_part.proto_id,
+            })
+            .unwrap();
+
+        assert!(Pin::new(&mut write_part).poll_next(&mut cx).is_ready());
+        assert!(write_part.dead);
+        assert!(write_part.high_write_buf.is_empty());
+        assert!(write_part.write_buf.is_empty());
+    }
+
+    #[test]
+    fn try_next_high_does_not_drain_normal_messages() {
+        let (tx, mut rx) = priority_mpsc::channel(16);
+        tx.try_send(ProtocolEvent::Message {
+            data: Bytes::from_static(b"data"),
+        })
+        .unwrap();
+        tx.try_quick_send(ProtocolEvent::Close {
+            id: 1,
+            proto_id: 1.into(),
+        })
+        .unwrap();
+
+        assert!(matches!(
+            rx.try_next_high().unwrap(),
+            Some(ProtocolEvent::Close { .. })
+        ));
+        assert!(matches!(
+            rx.try_next().unwrap(),
+            Some((Priority::Normal, ProtocolEvent::Message { .. }))
+        ));
     }
 }


### PR DESCRIPTION
## Summary

Fix substream write-side backpressure so blocked network writes stop draining upstream protocol events into internal buffers.

Previously, `send_data` could observe that the lower framed substream was still pending, but that state was not propagated back to `recv_event`. As a result, the substream could continue consuming messages from the bounded event channel and move them into internal write queues while the network was not writable.

## Changes

- Make `send_data` report whether the lower sink is still pending.
- Stop polling `event_receiver` while write-side backpressure is active.
- Propagate pending state through `handle_proto_event` and `flush`.
- Apply the same behavior to both `Substream` and `SubstreamWritePart`.
- Include both `high_write_buf` and `write_buf` in the write-buffer pressure check.

## Testing

```text
cargo fmt -p tentacle
git diff --check
cargo test -p tentacle
```