### PR TITLE
Use randomized HashMap for yamux stream IDs

### DIFF
--- a/yamux/Cargo.toml
+++ b/yamux/Cargo.toml
@@ -17,7 +17,6 @@ futures = { version = "0.3.0" }
 tokio = { version = "1.0.0" }
 tokio-util = { version = "0.7.0", features = ["codec"] }
 log = "0.4"
-nohash-hasher = "0.2"
 metrics = { version = "0.24", optional = true }
 
 futures-timer = { version = "3.0.2", optional = true }

--- a/yamux/src/session.rs
+++ b/yamux/src/session.rs
@@ -21,7 +21,6 @@ use futures::{
     channel::mpsc::{Receiver, Sender, UnboundedReceiver, UnboundedSender, channel, unbounded},
 };
 use log::{debug, log_enabled, trace};
-use nohash_hasher::IntMap;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::codec::Framed;
 
@@ -68,7 +67,7 @@ pub struct Session<T> {
     ping_id: u32,
 
     // streams maps a stream id to a sender of stream,
-    streams: IntMap<StreamId, Sender<Frame>>,
+    streams: HashMap<StreamId, Sender<Frame>>,
     // The StreamHandle not yet been polled
     pending_streams: VecDeque<StreamHandle>,
     // The buffer which will send to underlying network


### PR DESCRIPTION
## Summary

Replace the yamux active stream map with the standard `HashMap` and remove the `nohash-hasher` dependency from `tokio-yamux`.

Remote peers control inbound yamux stream IDs through frame headers. Using `nohash_hasher::IntMap` for those keys removes randomized hashing and makes insertion/lookup behavior dependent on attacker-chosen integer values. Switching back to the default `HashMap` restores randomized hashing for externally controlled stream IDs.

## Testing

- `cargo fmt`
- `cargo test -p tokio-yamux`