### PR TITLE
Validate wasm X25519 peer key length exactly

### DIFF
--- a/secio/src/dh_compat/mod.rs
+++ b/secio/src/dh_compat/mod.rs
@@ -67,6 +67,8 @@ mod ring_openssl_unix {
 
 #[cfg(test)]
 mod test {
+    use crate::error::SecioError;
+
     use super::*;
 
     #[test]
@@ -78,5 +80,20 @@ mod test {
         let secret_wasm = wasm_compat::agree(KeyAgreement::X25519, pk_wasm, &sk_native).unwrap();
 
         assert_eq!(secret_native, secret_wasm)
+    }
+
+    #[test]
+    fn test_wasm_agree_rejects_invalid_public_key_lengths() {
+        let (short_private_key, _) = wasm_compat::generate_agreement(KeyAgreement::X25519).unwrap();
+        let (long_private_key, _) = wasm_compat::generate_agreement(KeyAgreement::X25519).unwrap();
+
+        assert_eq!(
+            wasm_compat::agree(KeyAgreement::X25519, short_private_key, &[0; 31]).unwrap_err(),
+            SecioError::SecretGenerationFailed
+        );
+        assert_eq!(
+            wasm_compat::agree(KeyAgreement::X25519, long_private_key, &[0; 33]).unwrap_err(),
+            SecioError::SecretGenerationFailed
+        );
     }
 }

--- a/secio/src/dh_compat/wasm_compat.rs
+++ b/secio/src/dh_compat/wasm_compat.rs
@@ -27,7 +27,7 @@ pub fn agree(
     my_private_key: EphemeralPrivateKey,
     other_public_key: &[u8],
 ) -> Result<Vec<u8>, SecioError> {
-    if !matches!(algorithm, KeyAgreement::X25519) || other_public_key.len() < 32 {
+    if !matches!(algorithm, KeyAgreement::X25519) || other_public_key.len() != 32 {
         return Err(SecioError::SecretGenerationFailed);
     }
     let mut bytes = [0; 32];


### PR DESCRIPTION
## Summary

Reject malformed wasm X25519 peer public keys unless they are exactly 32 bytes.

The wasm `dh_compat::agree` implementation previously rejected keys shorter than 32 bytes but accepted longer slices. Those longer inputs then reached `copy_from_slice` against a fixed `[u8; 32]`, which could panic during secio handshakes with attacker-controlled exchange keys.

## Changes

- Require `other_public_key.len() == 32` for wasm X25519 agreement.
- Add regression coverage for both short and oversized peer public keys.

## Testing

- `cargo fmt`
- `cargo test -p tentacle-secio`