### PR TITLE
Backpressure small outbound messages by event count

### DIFF
--- a/tentacle/src/channel/bound.rs
+++ b/tentacle/src/channel/bound.rs
@@ -591,6 +591,32 @@ impl<T> Receiver<T> {
         }
     }
 
+    /// Tries to receive the next high-priority message without draining the
+    /// normal-priority queue.
+    pub(crate) fn try_next_high(&mut self) -> Result<Option<T>, TryRecvError> {
+        let inner = self
+            .inner
+            .as_mut()
+            .expect("Receiver::try_next_high called after `None`");
+
+        match unsafe { inner.quick_message_queue.pop_spin() } {
+            Some(msg) => {
+                self.unpark_one();
+                self.dec_num_messages();
+                Ok(Some(msg))
+            }
+            None => {
+                let state = decode_state(inner.state.load(SeqCst));
+                if state.is_closed() {
+                    self.inner = None;
+                    Ok(None)
+                } else {
+                    Err(TryRecvError { _priv: () })
+                }
+            }
+        }
+    }
+
     fn next_message(&mut self) -> Poll<Option<(Priority, T)>> {
         let inner = self
             .inner

--- a/tentacle/src/quic/session.rs
+++ b/tentacle/src/quic/session.rs
@@ -299,6 +299,16 @@ impl QuicSession {
     }
 
     #[inline]
+    fn pending_substream_events(&self) -> usize {
+        self.substreams.values().map(PriorityBuffer::len).sum()
+    }
+
+    #[inline]
+    fn substream_events_full(&self) -> bool {
+        self.pending_substream_events() > self.config.send_event_size()
+    }
+
+    #[inline]
     fn distribute_to_substream(&mut self, cx: &mut Context) {
         for buffer in self
             .substreams
@@ -594,6 +604,10 @@ impl QuicSession {
     }
 
     fn recv_service(&mut self, cx: &mut Context) -> Poll<Option<()>> {
+        if self.substream_events_full() {
+            return Poll::Pending;
+        }
+
         match Pin::new(&mut self.service_receiver).as_mut().poll_next(cx) {
             Poll::Ready(Some((priority, event))) => {
                 if !self.state.is_normal() {

--- a/tentacle/src/quic/session.rs
+++ b/tentacle/src/quic/session.rs
@@ -48,7 +48,9 @@ use crate::{
         config::{Meta, SessionConfig},
         future_task::BoxedFutureTask,
     },
-    session::{SessionEvent, SessionMeta, SessionState, split_spawn_framed},
+    session::{
+        SessionEvent, SessionMeta, SessionState, poll_next_service_event, split_spawn_framed,
+    },
     substream::{ProtocolEvent, SubstreamBuilder, SubstreamInner, SubstreamWritePartBuilder},
 };
 
@@ -124,6 +126,7 @@ pub(crate) struct QuicSession {
     service_sender: Buffer<SessionEvent>,
     /// InnerService → session.
     service_receiver: priority_mpsc::Receiver<SessionEvent>,
+    pending_service_event: Option<(Priority, SessionEvent)>,
 
     service_proto_senders: IntMap<ProtocolId, Buffer<ServiceProtocolEvent>>,
     session_proto_senders: IntMap<ProtocolId, Buffer<SessionProtocolEvent>>,
@@ -189,6 +192,7 @@ impl QuicSession {
             proto_event_receiver,
             service_sender: Buffer::new(service_sender),
             service_receiver,
+            pending_service_event: None,
             service_proto_senders: meta.service_proto_senders,
             session_proto_senders: meta.session_proto_senders,
             state: SessionState::Normal,
@@ -604,11 +608,14 @@ impl QuicSession {
     }
 
     fn recv_service(&mut self, cx: &mut Context) -> Poll<Option<()>> {
-        if self.substream_events_full() {
-            return Poll::Pending;
-        }
+        let allow_protocol_message = !self.substream_events_full();
 
-        match Pin::new(&mut self.service_receiver).as_mut().poll_next(cx) {
+        match poll_next_service_event(
+            &mut self.service_receiver,
+            &mut self.pending_service_event,
+            allow_protocol_message,
+            cx,
+        ) {
             Poll::Ready(Some((priority, event))) => {
                 if !self.state.is_normal() {
                     Poll::Ready(None)

--- a/tentacle/src/session.rs
+++ b/tentacle/src/session.rs
@@ -361,6 +361,16 @@ impl Session {
     }
 
     #[inline]
+    fn pending_substream_events(&self) -> usize {
+        self.substreams.values().map(PriorityBuffer::len).sum()
+    }
+
+    #[inline]
+    fn substream_events_full(&self) -> bool {
+        self.pending_substream_events() > self.config.send_event_size()
+    }
+
+    #[inline]
     fn distribute_to_substream(&mut self, cx: &mut Context) {
         for buffer in self
             .substreams
@@ -657,6 +667,10 @@ impl Session {
     }
 
     fn recv_service(&mut self, cx: &mut Context) -> Poll<Option<()>> {
+        if self.substream_events_full() {
+            return Poll::Pending;
+        }
+
         match Pin::new(&mut self.service_receiver).as_mut().poll_next(cx) {
             Poll::Ready(Some((priority, event))) => {
                 if !self.state.is_normal() {

--- a/tentacle/src/session.rs
+++ b/tentacle/src/session.rs
@@ -52,6 +52,37 @@ where
     Framed::from_parts(part).split()
 }
 
+pub(crate) fn poll_next_service_event(
+    receiver: &mut priority_mpsc::Receiver<SessionEvent>,
+    pending_event: &mut Option<(Priority, SessionEvent)>,
+    allow_protocol_message: bool,
+    cx: &mut Context,
+) -> Poll<Option<(Priority, SessionEvent)>> {
+    let next_event = if let Some(event) = pending_event.take() {
+        Poll::Ready(Some(event))
+    } else if allow_protocol_message {
+        Pin::new(receiver).as_mut().poll_next(cx)
+    } else {
+        match receiver.try_next_high() {
+            Ok(Some(event)) => Poll::Ready(Some((Priority::High, event))),
+            Ok(None) => Poll::Ready(None),
+            Err(_) => Poll::Pending,
+        }
+    };
+
+    match next_event {
+        Poll::Ready(Some((priority, event))) => {
+            if !allow_protocol_message && matches!(event, SessionEvent::ProtocolMessage { .. }) {
+                *pending_event = Some((priority, event));
+                Poll::Pending
+            } else {
+                Poll::Ready(Some((priority, event)))
+            }
+        }
+        other => other,
+    }
+}
+
 /// Event generated/received by the Session
 pub(crate) enum SessionEvent {
     /// Session close event
@@ -191,6 +222,7 @@ pub(crate) struct Session {
     service_sender: Buffer<SessionEvent>,
     /// Receive event from service
     service_receiver: priority_mpsc::Receiver<SessionEvent>,
+    pending_service_event: Option<(Priority, SessionEvent)>,
 
     service_proto_senders: IntMap<ProtocolId, Buffer<ServiceProtocolEvent>>,
     session_proto_senders: IntMap<ProtocolId, Buffer<SessionProtocolEvent>>,
@@ -253,6 +285,7 @@ impl Session {
             proto_event_receiver,
             service_sender: Buffer::new(service_sender),
             service_receiver,
+            pending_service_event: None,
             service_proto_senders: meta.service_proto_senders,
             session_proto_senders: meta.session_proto_senders,
             state: SessionState::Normal,
@@ -667,11 +700,14 @@ impl Session {
     }
 
     fn recv_service(&mut self, cx: &mut Context) -> Poll<Option<()>> {
-        if self.substream_events_full() {
-            return Poll::Pending;
-        }
+        let allow_protocol_message = !self.substream_events_full();
 
-        match Pin::new(&mut self.service_receiver).as_mut().poll_next(cx) {
+        match poll_next_service_event(
+            &mut self.service_receiver,
+            &mut self.pending_service_event,
+            allow_protocol_message,
+            cx,
+        ) {
             Poll::Ready(Some((priority, event))) => {
                 if !self.state.is_normal() {
                     Poll::Ready(None)
@@ -837,11 +873,17 @@ impl Stream for Session {
 
 #[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
-    use super::split_spawn_framed;
+    use super::{SessionEvent, poll_next_service_event, split_spawn_framed};
     use bytes::{Bytes, BytesMut};
-    use futures::StreamExt;
+    use futures::{StreamExt, task::noop_waker_ref};
+    use std::task::{Context, Poll};
     use tokio::io::duplex;
     use tokio_util::codec::{Encoder, FramedParts, LengthDelimitedCodec};
+
+    use crate::{
+        SessionId,
+        channel::mpsc::{self as priority_mpsc, Priority},
+    };
 
     #[tokio::test]
     async fn split_spawn_framed_reads_buffered_first_frame() {
@@ -863,6 +905,64 @@ mod tests {
             .expect("buffered frame should decode");
 
         assert_eq!(first.freeze(), Bytes::from_static(b"init"));
+    }
+
+    #[test]
+    fn service_backpressure_still_allows_high_priority_close() {
+        let (tx, mut rx) = priority_mpsc::channel(16);
+        tx.try_send(SessionEvent::ProtocolMessage {
+            proto_id: 1.into(),
+            data: Bytes::new(),
+        })
+        .unwrap();
+        tx.try_quick_send(SessionEvent::SessionClose { id: SessionId(1) })
+            .unwrap();
+
+        let waker = noop_waker_ref();
+        let mut cx = Context::from_waker(waker);
+        let mut pending = None;
+
+        assert!(matches!(
+            poll_next_service_event(&mut rx, &mut pending, false, &mut cx),
+            Poll::Ready(Some((Priority::High, SessionEvent::SessionClose { .. })))
+        ));
+        assert!(pending.is_none());
+
+        assert!(matches!(
+            poll_next_service_event(&mut rx, &mut pending, true, &mut cx),
+            Poll::Ready(Some((
+                Priority::Normal,
+                SessionEvent::ProtocolMessage { .. }
+            )))
+        ));
+    }
+
+    #[test]
+    fn service_backpressure_defers_protocol_messages() {
+        let (tx, mut rx) = priority_mpsc::channel(16);
+        tx.try_quick_send(SessionEvent::ProtocolMessage {
+            proto_id: 1.into(),
+            data: Bytes::new(),
+        })
+        .unwrap();
+
+        let waker = noop_waker_ref();
+        let mut cx = Context::from_waker(waker);
+        let mut pending = None;
+
+        assert!(matches!(
+            poll_next_service_event(&mut rx, &mut pending, false, &mut cx),
+            Poll::Pending
+        ));
+        assert!(matches!(
+            pending,
+            Some((Priority::High, SessionEvent::ProtocolMessage { .. }))
+        ));
+
+        assert!(matches!(
+            poll_next_service_event(&mut rx, &mut pending, true, &mut cx),
+            Poll::Ready(Some((Priority::High, SessionEvent::ProtocolMessage { .. })))
+        ));
     }
 }
 


### PR DESCRIPTION
## Summary

Add event-count backpressure before sessions drain more service events into substream buffers.

The existing blocked-session guard only used `pending_data_size`, which is based on payload bytes. Empty or very small outbound messages can therefore accumulate many queued protocol events without crossing the byte threshold. This change also caps pending substream events using the configured `send_event_size`.

## Changes

- Add pending substream event counting for yamux-backed sessions.
- Add the same event-count backpressure for QUIC sessions.
- Stop polling service events while substream buffers are already above the configured event threshold.

## Testing

- `cargo fmt`
- `cargo test -p tentacle`