### PR TITLE
Fix stale pending-byte accounting on dropped outbound messages

### DIFF
--- a/tentacle/src/buffer.rs
+++ b/tentacle/src/buffer.rs
@@ -55,6 +55,13 @@ impl<T> PriorityBuffer<T> {
     }
 
     pub fn try_send(&mut self, cx: &mut Context) -> SendResult {
+        self.try_send_with_drop(cx, |_| {})
+    }
+
+    pub fn try_send_with_drop<F>(&mut self, cx: &mut Context, mut on_drop: F) -> SendResult
+    where
+        F: FnMut(T),
+    {
         while let Some(event) = self.high_buffer.pop_front() {
             match self.sender.poll_ready(cx) {
                 Poll::Ready(Ok(())) => {
@@ -63,7 +70,8 @@ impl<T> PriorityBuffer<T> {
                             self.high_buffer.push_front(e.into_inner());
                             return SendResult::Pending;
                         } else {
-                            self.clear();
+                            on_drop(e.into_inner());
+                            self.clear_with(&mut on_drop);
                             return SendResult::Disconnect;
                         }
                     }
@@ -73,7 +81,8 @@ impl<T> PriorityBuffer<T> {
                     return SendResult::Pending;
                 }
                 Poll::Ready(Err(_)) => {
-                    self.clear();
+                    on_drop(event);
+                    self.clear_with(&mut on_drop);
                     return SendResult::Disconnect;
                 }
             }
@@ -86,7 +95,8 @@ impl<T> PriorityBuffer<T> {
                             self.normal_buffer.push_front(e.into_inner());
                             return SendResult::Pending;
                         } else {
-                            self.clear();
+                            on_drop(e.into_inner());
+                            self.clear_with(&mut on_drop);
                             return SendResult::Disconnect;
                         }
                     }
@@ -96,7 +106,8 @@ impl<T> PriorityBuffer<T> {
                     return SendResult::Pending;
                 }
                 Poll::Ready(Err(_)) => {
-                    self.clear();
+                    on_drop(event);
+                    self.clear_with(&mut on_drop);
                     return SendResult::Disconnect;
                 }
             }
@@ -105,9 +116,16 @@ impl<T> PriorityBuffer<T> {
         SendResult::Ok
     }
 
-    pub fn clear(&mut self) {
-        self.high_buffer.clear();
-        self.normal_buffer.clear();
+    pub fn clear_with<F>(&mut self, mut on_drop: F)
+    where
+        F: FnMut(T),
+    {
+        for event in self.high_buffer.drain(..) {
+            on_drop(event);
+        }
+        for event in self.normal_buffer.drain(..) {
+            on_drop(event);
+        }
     }
 }
 

--- a/tentacle/src/context.rs
+++ b/tentacle/src/context.rs
@@ -97,11 +97,11 @@ impl SessionContext {
 
     // Decrease when data sent to underlying Yamux Stream
     pub(crate) fn decr_pending_data_size(&self, data_size: usize) {
-        let _ =
-            self.pending_data_size
-                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
-                    Some(current.saturating_sub(data_size))
-                });
+        self.pending_data_size
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                Some(current.saturating_sub(data_size))
+            })
+            .ok();
     }
 
     /// Session is closed

--- a/tentacle/src/context.rs
+++ b/tentacle/src/context.rs
@@ -97,8 +97,11 @@ impl SessionContext {
 
     // Decrease when data sent to underlying Yamux Stream
     pub(crate) fn decr_pending_data_size(&self, data_size: usize) {
-        self.pending_data_size
-            .fetch_sub(data_size, Ordering::AcqRel);
+        let _ =
+            self.pending_data_size
+                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                    Some(current.saturating_sub(data_size))
+                });
     }
 
     /// Session is closed

--- a/tentacle/src/quic/session.rs
+++ b/tentacle/src/quic/session.rs
@@ -48,15 +48,14 @@ use crate::{
         config::{Meta, SessionConfig},
         future_task::BoxedFutureTask,
     },
-    session::{SessionEvent, SessionMeta, SessionState, split_spawn_framed},
-    substream::{ProtocolEvent, SubstreamBuilder, SubstreamInner, SubstreamWritePartBuilder},
+    session::{
+        SessionEvent, SessionMeta, SessionState, decr_pending_session_event, split_spawn_framed,
+    },
+    substream::{
+        ProtocolEvent, SubstreamBuilder, SubstreamInner, SubstreamWritePartBuilder,
+        decr_pending_protocol_message,
+    },
 };
-
-fn decr_pending_protocol_message(context: &SessionContext, event: ProtocolEvent) {
-    if let ProtocolEvent::Message { data } = event {
-        context.decr_pending_data_size(data.len());
-    }
-}
 
 /// Successfully-handshaken QUIC connection paired with the remote secio
 /// public key recovered from its tentacle identity extension.
@@ -470,7 +469,12 @@ impl QuicSession {
             }
             ProtocolEvent::Close { id, proto_id } => {
                 debug!("session [{}] proto [{}] closed", self.context.id, proto_id);
-                if self.substreams.remove(&id).is_some() {
+                if let Some(mut buffer) = self.substreams.remove(&id) {
+                    // Roll back the pending byte counter for any outbound
+                    // messages still queued in this substream's buffer that
+                    // will be dropped along with the substream.
+                    let context = self.context.clone();
+                    buffer.clear_with(|event| decr_pending_protocol_message(&context, event));
                     self.proto_streams.remove(&proto_id);
                 }
             }
@@ -612,6 +616,11 @@ impl QuicSession {
         match Pin::new(&mut self.service_receiver).as_mut().poll_next(cx) {
             Poll::Ready(Some((priority, event))) => {
                 if !self.state.is_normal() {
+                    // Event will be discarded; roll back pending bytes that
+                    // were incremented in `Service::handle_message` so the
+                    // counter does not stay inflated for the lifetime of this
+                    // `SessionContext`.
+                    decr_pending_session_event(&self.context, &event);
                     Poll::Ready(None)
                 } else {
                     self.handle_session_event(cx, event, priority);
@@ -753,8 +762,23 @@ impl QuicSession {
     /// connection. The owning `quinn::Endpoint` is kept alive elsewhere
     /// until its connections drain.
     fn clean(&mut self) {
-        self.substreams.clear();
+        // Drain any messages still queued for substreams so that
+        // `SessionContext::pending_data_size` reflects reality after the
+        // session is gone. Otherwise observers (e.g. the service layer
+        // holding an `Arc<SessionContext>`) would see stale, never-decreasing
+        // pending bytes.
+        let context = self.context.clone();
+        for (_, mut buffer) in self.substreams.drain() {
+            buffer.clear_with(|event| decr_pending_protocol_message(&context, event));
+        }
         self.service_receiver.close();
+        // Drain any inbound `SessionEvent`s still buffered in the channel so
+        // that `ProtocolMessage`s queued by the service (which already
+        // incremented `pending_data_size`) get their bytes rolled back before
+        // the receiver is dropped.
+        while let Ok(Some((_, event))) = self.service_receiver.try_next() {
+            decr_pending_session_event(&context, &event);
+        }
         self.proto_event_receiver.close();
         self.accepting = None;
         self.conn.close(0u32.into(), b"closed");

--- a/tentacle/src/quic/session.rs
+++ b/tentacle/src/quic/session.rs
@@ -52,6 +52,12 @@ use crate::{
     substream::{ProtocolEvent, SubstreamBuilder, SubstreamInner, SubstreamWritePartBuilder},
 };
 
+fn decr_pending_protocol_message(context: &SessionContext, event: ProtocolEvent) {
+    if let ProtocolEvent::Message { data } = event {
+        context.decr_pending_data_size(data.len());
+    }
+}
+
 /// Successfully-handshaken QUIC connection paired with the remote secio
 /// public key recovered from its tentacle identity extension.
 ///
@@ -300,12 +306,15 @@ impl QuicSession {
 
     #[inline]
     fn distribute_to_substream(&mut self, cx: &mut Context) {
+        let context = self.context.clone();
         for buffer in self
             .substreams
             .values_mut()
             .filter(|buffer| !buffer.is_empty())
         {
-            if let SendResult::Pending = buffer.try_send(cx) {
+            if let SendResult::Pending = buffer
+                .try_send_with_drop(cx, |event| decr_pending_protocol_message(&context, event))
+            {
                 if self.context.pending_data_size() > self.config.send_buffer_size {
                     self.state = SessionState::Abnormal;
                     warn!(
@@ -316,7 +325,7 @@ impl QuicSession {
                         self.config.send_buffer_size,
                         self.context.pending_data_size()
                     );
-                    buffer.clear();
+                    buffer.clear_with(|event| decr_pending_protocol_message(&context, event));
                     self.event_output(
                         cx,
                         SessionEvent::ChangeState {
@@ -504,17 +513,23 @@ impl QuicSession {
     fn handle_session_event(&mut self, cx: &mut Context, event: SessionEvent, priority: Priority) {
         match event {
             SessionEvent::ProtocolMessage { proto_id, data, .. } => {
-                if let Some(stream_id) = self.proto_streams.get(&proto_id) {
-                    if let Some(buffer) = self.substreams.get_mut(stream_id) {
-                        let event = ProtocolEvent::Message { data };
-                        if priority.is_high() {
-                            buffer.push_high(event)
-                        } else {
-                            buffer.push_normal(event)
-                        }
-                        buffer.try_send(cx);
+                if let Some(buffer) = self
+                    .proto_streams
+                    .get(&proto_id)
+                    .and_then(|stream_id| self.substreams.get_mut(stream_id))
+                {
+                    let context = self.context.clone();
+                    let event = ProtocolEvent::Message { data };
+                    if priority.is_high() {
+                        buffer.push_high(event)
+                    } else {
+                        buffer.push_normal(event)
                     }
+                    buffer.try_send_with_drop(cx, |event| {
+                        decr_pending_protocol_message(&context, event)
+                    });
                 } else {
+                    self.context.decr_pending_data_size(data.len());
                     trace!("protocol {} not ready", proto_id);
                 }
             }

--- a/tentacle/src/service.rs
+++ b/tentacle/src/service.rs
@@ -818,16 +818,19 @@ where
             // Send data to the specified protocol for the specified session.
             TargetSession::Single(id) => {
                 if let Some(control) = self.sessions.get_mut(&id) {
-                    control.inner.incr_pending_data_size(data.len());
+                    let data_size = data.len();
+                    control.inner.incr_pending_data_size(data_size);
                     let _ignore = control
                         .send(priority, SessionEvent::ProtocolMessage { proto_id, data })
-                        .await;
+                        .await
+                        .map_err(|_| control.inner.decr_pending_data_size(data_size));
                 }
             }
             TargetSession::Multi(iter) => {
                 for id in iter {
                     if let Some(control) = self.sessions.get_mut(&id) {
-                        control.inner.incr_pending_data_size(data.len());
+                        let data_size = data.len();
+                        control.inner.incr_pending_data_size(data_size);
                         let _ignore = control
                             .send(
                                 priority,
@@ -836,7 +839,8 @@ where
                                     data: data.clone(),
                                 },
                             )
-                            .await;
+                            .await
+                            .map_err(|_| control.inner.decr_pending_data_size(data_size));
                     }
                 }
             }
@@ -849,7 +853,8 @@ where
                         proto_id,
                         data.len()
                     );
-                    control.inner.incr_pending_data_size(data.len());
+                    let data_size = data.len();
+                    control.inner.incr_pending_data_size(data_size);
                     let _ignore = control
                         .send(
                             priority,
@@ -858,7 +863,8 @@ where
                                 data: data.clone(),
                             },
                         )
-                        .await;
+                        .await
+                        .map_err(|_| control.inner.decr_pending_data_size(data_size));
                 }
             }
             // Broadcast data for a specified protocol.
@@ -870,7 +876,8 @@ where
                     data.len()
                 );
                 for control in self.sessions.values_mut() {
-                    control.inner.incr_pending_data_size(data.len());
+                    let data_size = data.len();
+                    control.inner.incr_pending_data_size(data_size);
                     let _ignore = control
                         .send(
                             priority,
@@ -879,7 +886,8 @@ where
                                 data: data.clone(),
                             },
                         )
-                        .await;
+                        .await
+                        .map_err(|_| control.inner.decr_pending_data_size(data_size));
                 }
             }
         }

--- a/tentacle/src/session.rs
+++ b/tentacle/src/session.rs
@@ -31,12 +31,19 @@ use crate::{
         config::{Meta, SessionConfig},
         future_task::BoxedFutureTask,
     },
-    substream::{ProtocolEvent, SubstreamBuilder, SubstreamInner, SubstreamWritePartBuilder},
+    substream::{
+        ProtocolEvent, SubstreamBuilder, SubstreamInner, SubstreamWritePartBuilder,
+        decr_pending_protocol_message,
+    },
     transports::MultiIncoming,
 };
 
-fn decr_pending_protocol_message(context: &SessionContext, event: ProtocolEvent) {
-    if let ProtocolEvent::Message { data } = event {
+/// Roll back the session pending byte counter for a dropped inbound
+/// `SessionEvent`. Only `ProtocolMessage` is accounted into
+/// `SessionContext::pending_data_size`; all other variants are no-ops.
+#[inline]
+pub(crate) fn decr_pending_session_event(context: &SessionContext, event: &SessionEvent) {
+    if let SessionEvent::ProtocolMessage { data, .. } = event {
         context.decr_pending_data_size(data.len());
     }
 }
@@ -533,7 +540,12 @@ impl Session {
             }
             ProtocolEvent::Close { id, proto_id } => {
                 debug!("session [{}] proto [{}] closed", self.context.id, proto_id);
-                if self.substreams.remove(&id).is_some() {
+                if let Some(mut buffer) = self.substreams.remove(&id) {
+                    // Roll back the pending byte counter for any outbound
+                    // messages still queued in this substream's buffer that
+                    // will be dropped along with the substream.
+                    let context = self.context.clone();
+                    buffer.clear_with(|event| decr_pending_protocol_message(&context, event));
                     self.proto_streams.remove(&proto_id);
                 }
             }
@@ -675,6 +687,11 @@ impl Session {
         match Pin::new(&mut self.service_receiver).as_mut().poll_next(cx) {
             Poll::Ready(Some((priority, event))) => {
                 if !self.state.is_normal() {
+                    // Event will be discarded; roll back pending bytes that
+                    // were incremented in `Service::handle_message` so the
+                    // counter does not stay inflated for the lifetime of this
+                    // `SessionContext`.
+                    decr_pending_session_event(&self.context, &event);
                     Poll::Ready(None)
                 } else {
                     self.handle_session_event(cx, event, priority);
@@ -749,8 +766,23 @@ impl Session {
 
     /// Clean env
     fn clean(&mut self) {
-        self.substreams.clear();
+        // Drain any messages still queued for substreams so that
+        // `SessionContext::pending_data_size` reflects reality after the
+        // session is gone. Otherwise observers (e.g. the service layer
+        // holding an `Arc<SessionContext>`) would see stale, never-decreasing
+        // pending bytes.
+        let context = self.context.clone();
+        for (_, mut buffer) in self.substreams.drain() {
+            buffer.clear_with(|event| decr_pending_protocol_message(&context, event));
+        }
         self.service_receiver.close();
+        // Drain any inbound `SessionEvent`s still buffered in the channel so
+        // that `ProtocolMessage`s queued by the service (which already
+        // incremented `pending_data_size`) get their bytes rolled back before
+        // the receiver is dropped.
+        while let Ok(Some((_, event))) = self.service_receiver.try_next() {
+            decr_pending_session_event(&context, &event);
+        }
         self.proto_event_receiver.close();
 
         let mut control = self.control.clone();

--- a/tentacle/src/session.rs
+++ b/tentacle/src/session.rs
@@ -35,6 +35,12 @@ use crate::{
     transports::MultiIncoming,
 };
 
+fn decr_pending_protocol_message(context: &SessionContext, event: ProtocolEvent) {
+    if let ProtocolEvent::Message { data } = event {
+        context.decr_pending_data_size(data.len());
+    }
+}
+
 pub trait AsyncRw: AsyncWrite + AsyncRead {}
 
 impl<T: AsyncRead + AsyncWrite> AsyncRw for T {}
@@ -362,12 +368,15 @@ impl Session {
 
     #[inline]
     fn distribute_to_substream(&mut self, cx: &mut Context) {
+        let context = self.context.clone();
         for buffer in self
             .substreams
             .values_mut()
             .filter(|buffer| !buffer.is_empty())
         {
-            if let SendResult::Pending = buffer.try_send(cx) {
+            if let SendResult::Pending = buffer
+                .try_send_with_drop(cx, |event| decr_pending_protocol_message(&context, event))
+            {
                 if self.context.pending_data_size() > self.config.send_buffer_size {
                     self.state = SessionState::Abnormal;
                     warn!(
@@ -378,7 +387,7 @@ impl Session {
                         self.config.send_buffer_size,
                         self.context.pending_data_size()
                     );
-                    buffer.clear();
+                    buffer.clear_with(|event| decr_pending_protocol_message(&context, event));
                     self.event_output(
                         cx,
                         SessionEvent::ChangeState {
@@ -567,17 +576,23 @@ impl Session {
     fn handle_session_event(&mut self, cx: &mut Context, event: SessionEvent, priority: Priority) {
         match event {
             SessionEvent::ProtocolMessage { proto_id, data, .. } => {
-                if let Some(stream_id) = self.proto_streams.get(&proto_id) {
-                    if let Some(buffer) = self.substreams.get_mut(stream_id) {
-                        let event = ProtocolEvent::Message { data };
-                        if priority.is_high() {
-                            buffer.push_high(event)
-                        } else {
-                            buffer.push_normal(event)
-                        }
-                        buffer.try_send(cx);
+                if let Some(buffer) = self
+                    .proto_streams
+                    .get(&proto_id)
+                    .and_then(|stream_id| self.substreams.get_mut(stream_id))
+                {
+                    let context = self.context.clone();
+                    let event = ProtocolEvent::Message { data };
+                    if priority.is_high() {
+                        buffer.push_high(event)
+                    } else {
+                        buffer.push_normal(event)
                     }
+                    buffer.try_send_with_drop(cx, |event| {
+                        decr_pending_protocol_message(&context, event)
+                    });
                 } else {
+                    self.context.decr_pending_data_size(data.len());
                     trace!("protocol {} not ready", proto_id);
                 }
             }

--- a/tentacle/src/substream.rs
+++ b/tentacle/src/substream.rs
@@ -75,6 +75,16 @@ impl AsyncWrite for SubstreamInner {
     }
 }
 
+/// Roll back the session pending byte counter for a dropped outbound protocol
+/// message. No-op for non-`Message` variants since only `Message` carries
+/// bytes accounted in `SessionContext::pending_data_size`.
+#[inline]
+pub(crate) fn decr_pending_protocol_message(context: &SessionContext, event: ProtocolEvent) {
+    if let ProtocolEvent::Message { data } = event {
+        context.decr_pending_data_size(data.len());
+    }
+}
+
 /// Event generated/received by the protocol stream
 #[derive(Debug)]
 pub(crate) enum ProtocolEvent {
@@ -249,6 +259,16 @@ where
     /// Close protocol sub stream
     fn close_proto_stream(&mut self, cx: &mut Context) {
         self.event_receiver.close();
+        // Drain any in-flight messages that the session pushed into our event
+        // channel but have not yet been polled. Their bytes were counted into
+        // `pending_data_size` when the service enqueued them; if we drop them
+        // silently the counter would leak.
+        while let Ok(Some((_, event))) = self.event_receiver.try_next() {
+            decr_pending_protocol_message(&self.context, event);
+        }
+        // Any frames still queued here will be dropped together with this
+        // substream, roll back their pending byte accounting before dropping.
+        self.clear_write_buffers();
         if let Poll::Ready(Err(e)) = Pin::new(self.substream.get_mut()).poll_shutdown(cx) {
             log::trace!("sub stream poll shutdown err {}", e)
         }
@@ -304,6 +324,9 @@ where
     /// When send or receive message error, output error and close stream
     fn error_close(&mut self, cx: &mut Context, error: io::Error) {
         self.dead = true;
+        // Roll back pending bytes for any frames still queued: this substream
+        // is going away and they will not be sent.
+        self.clear_write_buffers();
         match error.kind() {
             ErrorKind::BrokenPipe
             | ErrorKind::ConnectionAborted
@@ -849,6 +872,9 @@ where
     /// When send or receive message error, output error and close stream
     fn error_close(&mut self, cx: &mut Context, error: io::Error) {
         self.dead = true;
+        // Roll back pending bytes for any frames still queued: this substream
+        // is going away and they will not be sent.
+        self.clear_write_buffers();
         match error.kind() {
             ErrorKind::BrokenPipe
             | ErrorKind::ConnectionAborted
@@ -866,6 +892,16 @@ where
 
     fn close_proto_stream(&mut self, cx: &mut Context) {
         self.event_receiver.close();
+        // Drain any in-flight messages that the session pushed into our event
+        // channel but have not yet been polled. Their bytes were counted into
+        // `pending_data_size` when the service enqueued them; if we drop them
+        // silently the counter would leak.
+        while let Ok(Some((_, event))) = self.event_receiver.try_next() {
+            decr_pending_protocol_message(&self.context, event);
+        }
+        // Any frames still queued here will be dropped together with this
+        // substream, roll back their pending byte accounting before dropping.
+        self.clear_write_buffers();
         if let Poll::Ready(Err(e)) = Pin::new(&mut self.substream).poll_close(cx) {
             log::trace!("sub stream poll shutdown err {}", e)
         }

--- a/tentacle/src/substream.rs
+++ b/tentacle/src/substream.rs
@@ -172,6 +172,16 @@ where
         }
     }
 
+    fn clear_write_buffers(&mut self) {
+        let data_size = self
+            .high_write_buf
+            .drain(..)
+            .chain(self.write_buf.drain(..))
+            .map(|frame| frame.len())
+            .sum();
+        self.context.decr_pending_data_size(data_size);
+    }
+
     /// Sink `start_send` Ready -> data send to buffer
     /// Sink `start_send` NotReady -> buffer full need poll complete
     #[inline]
@@ -184,11 +194,18 @@ where
         let data_size = frame.len();
         let mut sink = Pin::new(&mut self.substream);
 
-        match sink.as_mut().poll_ready(cx)? {
-            Poll::Ready(()) => {
-                sink.as_mut().start_send(frame)?;
+        match sink.as_mut().poll_ready(cx) {
+            Poll::Ready(Ok(())) => {
+                if let Err(err) = sink.as_mut().start_send(frame) {
+                    self.context.decr_pending_data_size(data_size);
+                    return Err(err);
+                }
                 self.context.decr_pending_data_size(data_size);
                 Ok(false)
+            }
+            Poll::Ready(Err(err)) => {
+                self.context.decr_pending_data_size(data_size);
+                Err(err)
             }
             Poll::Pending => {
                 self.push_front(priority, frame);
@@ -323,11 +340,12 @@ where
                             error: err,
                         },
                     );
+                    self.clear_write_buffers();
                     self.dead = true;
                 }
             }
             ProtocolEvent::Close { .. } => {
-                self.write_buf.clear();
+                self.clear_write_buffers();
                 self.dead = true;
             }
             _ => (),
@@ -682,6 +700,16 @@ where
         }
     }
 
+    fn clear_write_buffers(&mut self) {
+        let data_size = self
+            .high_write_buf
+            .drain(..)
+            .chain(self.write_buf.drain(..))
+            .map(|frame| frame.len())
+            .sum();
+        self.context.decr_pending_data_size(data_size);
+    }
+
     /// Sink `start_send` Ready -> data send to buffer
     /// Sink `start_send` NotReady -> buffer full need poll complete
     #[inline]
@@ -694,11 +722,18 @@ where
         let data_size = frame.len();
         let mut sink = Pin::new(&mut self.substream);
 
-        match sink.as_mut().poll_ready(cx)? {
-            Poll::Ready(()) => {
-                sink.as_mut().start_send(frame)?;
+        match sink.as_mut().poll_ready(cx) {
+            Poll::Ready(Ok(())) => {
+                if let Err(err) = sink.as_mut().start_send(frame) {
+                    self.context.decr_pending_data_size(data_size);
+                    return Err(err);
+                }
                 self.context.decr_pending_data_size(data_size);
                 Ok(false)
+            }
+            Poll::Ready(Err(err)) => {
+                self.context.decr_pending_data_size(data_size);
+                Err(err)
             }
             Poll::Pending => {
                 self.push_front(priority, frame);
@@ -773,11 +808,12 @@ where
                             error: err,
                         },
                     );
+                    self.clear_write_buffers();
                     self.dead = true;
                 }
             }
             ProtocolEvent::Close { .. } => {
-                self.write_buf.clear();
+                self.clear_write_buffers();
                 self.dead = true;
             }
             _ => (),


### PR DESCRIPTION
## Summary

- Roll back `pending_data_size` when outbound protocol messages fail to enqueue into a session.
- Decrement pending bytes when protocol messages are dropped before reaching a substream, including missing protocol streams and disconnected substream queues.
- Account for pending bytes when substream write buffers are cleared or when sink readiness/send errors drop frames.
- Make pending-byte decrement saturating to avoid underflow on defensive cleanup paths.

## Motivation

`pending_data_size` was incremented before outbound messages reached the substream sink, but it was only decremented after successful substream send acceptance. Messages dropped earlier could leave the counter stale and inflated, causing incorrect backpressure decisions and possible premature abnormal session handling.

## Testing

- `cargo test -p tentacle`