### PR TITLE
Ensure yamux streams notify session after half-close FIN

### DIFF
--- a/tentacle/tests/test_session_protocol_order.rs
+++ b/tentacle/tests/test_session_protocol_order.rs
@@ -5,7 +5,7 @@ use std::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     thread,
-    time::Duration,
+    time::{Duration, Instant},
 };
 use tentacle::{
     ProtocolId, async_trait,
@@ -89,6 +89,17 @@ fn create_meta(id: ProtocolId) -> (ProtocolMeta, Arc<AtomicUsize>, Arc<AtomicBoo
     )
 }
 
+fn wait_for_result(result: &AtomicBool, timeout: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if result.load(Ordering::SeqCst) {
+            return true;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    result.load(Ordering::SeqCst)
+}
+
 fn test_session_protocol_order(secio: bool) {
     let (meta, count, res_1) = create_meta(1.into());
     let (addr_sender, addr_receiver) = channel::oneshot::channel::<Multiaddr>();
@@ -122,8 +133,8 @@ fn test_session_protocol_order(secio: bool) {
     });
     handle_2.join().unwrap();
 
-    assert!(res_1.load(Ordering::SeqCst));
-    assert!(res_2.load(Ordering::SeqCst));
+    assert!(wait_for_result(&res_1, Duration::from_secs(10)));
+    assert!(wait_for_result(&res_2, Duration::from_secs(10)));
 }
 
 #[test]

--- a/yamux/src/stream.rs
+++ b/yamux/src/stream.rs
@@ -189,7 +189,7 @@ impl StreamHandle {
                     self.state = StreamState::RemoteClosing;
                 }
                 StreamState::LocalClosing => {
-                    self.state = StreamState::Closed;
+                    return self.close();
                 }
                 _ => return Err(Error::UnexpectedFlag),
             }
@@ -894,6 +894,51 @@ mod test {
             assert_eq!(&b[..4], b"1234");
 
             assert_eq!(stream.state, StreamState::LocalClosing);
+        });
+    }
+
+    #[test]
+    fn test_remote_fin_after_local_close_notifies_session() {
+        let rt = rt();
+        rt.block_on(async {
+            let (mut frame_sender, frame_receiver) = channel(2);
+            let (unbound_sender, mut unbound_receiver) = unbounded();
+            let mut stream = StreamHandle::new(
+                0,
+                unbound_sender,
+                frame_receiver,
+                StreamState::Init,
+                INITIAL_STREAM_WINDOW,
+            );
+
+            stream.shutdown().await.unwrap();
+            assert_eq!(stream.state, StreamState::LocalClosing);
+
+            let event = unbound_receiver.next().await.unwrap();
+            match event {
+                StreamEvent::Frame(frame) => {
+                    assert!(frame.flags().contains(Flag::Fin));
+                    assert_eq!(frame.ty(), Type::WindowUpdate);
+                }
+                _ => panic!("must be fin window update"),
+            }
+
+            let flags = Flags::from(Flag::Fin);
+            let frame = Frame::new_window_update(flags, 0, 0);
+            frame_sender.send(frame).await.unwrap();
+
+            let mut b = [0; 1024];
+            assert_eq!(stream.read(&mut b).await.unwrap(), 0);
+            assert_eq!(stream.state, StreamState::Closed);
+
+            let event = unbound_receiver.next().await.unwrap();
+            match event {
+                StreamEvent::Closed(0) => (),
+                _ => panic!("must notify session that stream is closed"),
+            }
+
+            drop(stream);
+            assert!(unbound_receiver.try_recv().is_err());
         });
     }
 


### PR DESCRIPTION
## Summary

- emit `StreamEvent::Closed` when a locally half-closed yamux stream receives the peer's `FIN`
- avoid leaving closed streams registered in the parent session
- add regression coverage for the `LocalClosing + FIN` path

## Rationale

A stream that called `shutdown()` enters `LocalClosing`. When the peer later sends `FIN`, the stream previously transitioned directly to `Closed` without notifying the parent session. Since `Drop` skips cleanup for `Closed` streams, the session could retain the stream entry and continue counting it against `max_stream_count`.

This change routes that transition through the existing `close()` cleanup path.

## Tests

- `cargo fmt --check`
- `cargo test -p tokio-yamux stream::test -- --nocapture`