### PR TITLE
Avoid local DNS resolution for SOCKS proxy dials

### DIFF
--- a/tentacle/src/runtime/tokio_runtime/mod.rs
+++ b/tentacle/src/runtime/tokio_runtime/mod.rs
@@ -143,7 +143,7 @@ async fn connect_direct(
     socket.connect(addr).await
 }
 
-async fn connect_by_proxy(
+pub(crate) async fn connect_by_proxy(
     target_addr: String,
     target_port: u16,
     mut proxy_server_url: url::Url,
@@ -196,33 +196,14 @@ pub(crate) async fn connect(
         )
         .await
         .map_err(|err| {
-            io::Error::other(format!("connect_by_proxy: {}, error: {}", proxy_url, err))
+            io::Error::other(format!(
+                "connect_by_proxy: {}, error: {}",
+                redact_auth_from_url(&proxy_url),
+                err
+            ))
         }),
         None => connect_direct(target_addr, socket_transformer).await,
     }
-}
-
-pub(crate) async fn connect_proxy(
-    target_addr: String,
-    target_port: u16,
-    tcp_config: TcpSocketConfig,
-) -> io::Result<TcpStream> {
-    let TcpSocketConfig {
-        socket_transformer: _,
-        proxy_url,
-        onion_url: _,
-        proxy_random_auth,
-    } = tcp_config;
-
-    let proxy_url = proxy_url.ok_or_else(|| io::Error::other("missing socks proxy config"))?;
-    connect_by_proxy(
-        target_addr,
-        target_port,
-        proxy_url.clone(),
-        proxy_random_auth,
-    )
-    .await
-    .map_err(|err| io::Error::other(format!("connect_by_proxy: {}, error: {}", proxy_url, err)))
 }
 
 pub(crate) async fn connect_onion(

--- a/tentacle/src/runtime/tokio_runtime/mod.rs
+++ b/tentacle/src/runtime/tokio_runtime/mod.rs
@@ -202,6 +202,29 @@ pub(crate) async fn connect(
     }
 }
 
+pub(crate) async fn connect_proxy(
+    target_addr: String,
+    target_port: u16,
+    tcp_config: TcpSocketConfig,
+) -> io::Result<TcpStream> {
+    let TcpSocketConfig {
+        socket_transformer: _,
+        proxy_url,
+        onion_url: _,
+        proxy_random_auth,
+    } = tcp_config;
+
+    let proxy_url = proxy_url.ok_or_else(|| io::Error::other("missing socks proxy config"))?;
+    connect_by_proxy(
+        target_addr,
+        target_port,
+        proxy_url.clone(),
+        proxy_random_auth,
+    )
+    .await
+    .map_err(|err| io::Error::other(format!("connect_by_proxy: {}, error: {}", proxy_url, err)))
+}
+
 pub(crate) async fn connect_onion(
     onion_addr: MultiAddr,
     tcp_config: TcpSocketConfig,

--- a/tentacle/src/transports/mod.rs
+++ b/tentacle/src/transports/mod.rs
@@ -474,6 +474,31 @@ mod os {
         }
     }
 
+    /// TCP dial through a SOCKS proxy with proxy-side hostname resolution.
+    #[inline(always)]
+    pub async fn tcp_proxy_dial(
+        target_addr: String,
+        target_port: u16,
+        tcp_config: TcpSocketConfig,
+        timeout: Duration,
+    ) -> Result<TcpStream> {
+        match crate::runtime::timeout(
+            timeout,
+            crate::runtime::connect_proxy(target_addr, target_port, tcp_config),
+        )
+        .await
+        {
+            Err(_) => Err(TransportErrorKind::Io(io::ErrorKind::TimedOut.into())),
+            Ok(res) => res.map_err(|err| {
+                if err.to_string().contains("connect_by_proxy") {
+                    TransportErrorKind::ProxyError(err)
+                } else {
+                    err.into()
+                }
+            }),
+        }
+    }
+
     /// onion common dial realization
     #[inline(always)]
     pub async fn onion_dial(

--- a/tentacle/src/transports/mod.rs
+++ b/tentacle/src/transports/mod.rs
@@ -474,31 +474,6 @@ mod os {
         }
     }
 
-    /// TCP dial through a SOCKS proxy with proxy-side hostname resolution.
-    #[inline(always)]
-    pub async fn tcp_proxy_dial(
-        target_addr: String,
-        target_port: u16,
-        tcp_config: TcpSocketConfig,
-        timeout: Duration,
-    ) -> Result<TcpStream> {
-        match crate::runtime::timeout(
-            timeout,
-            crate::runtime::connect_proxy(target_addr, target_port, tcp_config),
-        )
-        .await
-        {
-            Err(_) => Err(TransportErrorKind::Io(io::ErrorKind::TimedOut.into())),
-            Ok(res) => res.map_err(|err| {
-                if err.to_string().contains("connect_by_proxy") {
-                    TransportErrorKind::ProxyError(err)
-                } else {
-                    err.into()
-                }
-            }),
-        }
-    }
-
     /// onion common dial realization
     #[inline(always)]
     pub async fn onion_dial(

--- a/tentacle/src/transports/tcp.rs
+++ b/tentacle/src/transports/tcp.rs
@@ -7,13 +7,13 @@ use std::{
 use crate::service::TlsConfig;
 use crate::{
     error::TransportErrorKind,
-    multiaddr::{Multiaddr, Protocol},
-    runtime::TcpStream,
+    multiaddr::Multiaddr,
+    runtime::{self, TcpStream},
     service::config::TcpSocketConfig,
     transports::{
         Result, TcpListenMode, TransportDial, TransportFuture, TransportListen,
         tcp_base_listen::{TcpBaseListenerEnum, UpgradeMode, bind},
-        tcp_dial, tcp_proxy_dial,
+        tcp_dial,
     },
     utils::{dns::DnsResolver, multiaddr_to_socketaddr},
 };
@@ -33,33 +33,6 @@ async fn connect(
         }
         None => Err(TransportErrorKind::NotSupported(original.unwrap_or(addr))),
     }
-}
-
-fn dns_tcp_target(address: &Multiaddr) -> Option<(String, u16)> {
-    let mut iter = address.iter().peekable();
-
-    while iter.peek().is_some() {
-        match iter.peek() {
-            Some(Protocol::Dns4(_)) | Some(Protocol::Dns6(_)) => {}
-            _ => {
-                let _ignore = iter.next();
-                continue;
-            }
-        }
-
-        let proto1 = iter.next()?;
-        let proto2 = iter.next()?;
-
-        match (proto1, proto2) {
-            (Protocol::Dns4(domain), Protocol::Tcp(port))
-            | (Protocol::Dns6(domain), Protocol::Tcp(port)) => {
-                return Some((domain.into_owned(), port));
-            }
-            _ => {}
-        }
-    }
-
-    None
 }
 
 /// Tcp transport
@@ -156,20 +129,41 @@ impl TransportDial for TcpTransport {
     type DialFuture = TcpDialFuture;
 
     fn dial(self, address: Multiaddr) -> Result<Self::DialFuture> {
-        if self.tcp_config.proxy_url.is_some() {
-            if let Some((target_addr, target_port)) = dns_tcp_target(&address) {
-                let task = async move {
-                    let stream =
-                        tcp_proxy_dial(target_addr, target_port, self.tcp_config, self.timeout)
-                            .await?;
-                    Ok((address, stream))
-                };
-                return Ok(TransportFuture::new(Box::pin(task)));
-            }
-        }
-
         match DnsResolver::new(address.clone()) {
             Some(dns) => {
+                if let Some(proxy_url) = self.tcp_config.proxy_url.clone() {
+                    let (target_addr, target_port) = dns.tcp_target();
+                    let target_addr = target_addr.to_owned();
+                    let proxy_random_auth = self.tcp_config.proxy_random_auth;
+                    let timeout = self.timeout;
+                    let task = async move {
+                        let stream = match runtime::timeout(
+                            timeout,
+                            runtime::connect_by_proxy(
+                                target_addr,
+                                target_port,
+                                proxy_url,
+                                proxy_random_auth,
+                            ),
+                        )
+                        .await
+                        {
+                            Err(_) => {
+                                Err(TransportErrorKind::Io(std::io::ErrorKind::TimedOut.into()))
+                            }
+                            Ok(res) => res.map_err(|err| {
+                                if err.to_string().contains("connect_by_proxy") {
+                                    TransportErrorKind::ProxyError(err)
+                                } else {
+                                    err.into()
+                                }
+                            }),
+                        }?;
+                        Ok((address, stream))
+                    };
+                    return Ok(TransportFuture::new(Box::pin(task)));
+                }
+
                 // Why do this?
                 // Because here need to save the original address as an index to open the specified protocol.
                 let task = connect(

--- a/tentacle/src/transports/tcp.rs
+++ b/tentacle/src/transports/tcp.rs
@@ -7,13 +7,13 @@ use std::{
 use crate::service::TlsConfig;
 use crate::{
     error::TransportErrorKind,
-    multiaddr::Multiaddr,
+    multiaddr::{Multiaddr, Protocol},
     runtime::TcpStream,
     service::config::TcpSocketConfig,
     transports::{
         Result, TcpListenMode, TransportDial, TransportFuture, TransportListen,
         tcp_base_listen::{TcpBaseListenerEnum, UpgradeMode, bind},
-        tcp_dial,
+        tcp_dial, tcp_proxy_dial,
     },
     utils::{dns::DnsResolver, multiaddr_to_socketaddr},
 };
@@ -33,6 +33,33 @@ async fn connect(
         }
         None => Err(TransportErrorKind::NotSupported(original.unwrap_or(addr))),
     }
+}
+
+fn dns_tcp_target(address: &Multiaddr) -> Option<(String, u16)> {
+    let mut iter = address.iter().peekable();
+
+    while iter.peek().is_some() {
+        match iter.peek() {
+            Some(Protocol::Dns4(_)) | Some(Protocol::Dns6(_)) => {}
+            _ => {
+                let _ignore = iter.next();
+                continue;
+            }
+        }
+
+        let proto1 = iter.next()?;
+        let proto2 = iter.next()?;
+
+        match (proto1, proto2) {
+            (Protocol::Dns4(domain), Protocol::Tcp(port))
+            | (Protocol::Dns6(domain), Protocol::Tcp(port)) => {
+                return Some((domain.into_owned(), port));
+            }
+            _ => {}
+        }
+    }
+
+    None
 }
 
 /// Tcp transport
@@ -129,6 +156,18 @@ impl TransportDial for TcpTransport {
     type DialFuture = TcpDialFuture;
 
     fn dial(self, address: Multiaddr) -> Result<Self::DialFuture> {
+        if self.tcp_config.proxy_url.is_some() {
+            if let Some((target_addr, target_port)) = dns_tcp_target(&address) {
+                let task = async move {
+                    let stream =
+                        tcp_proxy_dial(target_addr, target_port, self.tcp_config, self.timeout)
+                            .await?;
+                    Ok((address, stream))
+                };
+                return Ok(TransportFuture::new(Box::pin(task)));
+            }
+        }
+
         match DnsResolver::new(address.clone()) {
             Some(dns) => {
                 // Why do this?
@@ -148,5 +187,70 @@ impl TransportDial for TcpTransport {
                 Ok(TransportFuture::new(Box::pin(dial)))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::channel::oneshot;
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpListener,
+    };
+
+    #[tokio::test]
+    async fn proxy_dns_dial_sends_hostname_to_socks_server() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_addr = listener.local_addr().unwrap();
+        let (target_sender, target_receiver) = oneshot::channel();
+
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+
+            let mut greeting = [0; 2];
+            socket.read_exact(&mut greeting).await.unwrap();
+            assert_eq!(greeting[0], 5);
+            let mut methods = vec![0; greeting[1] as usize];
+            socket.read_exact(&mut methods).await.unwrap();
+            assert!(methods.contains(&0));
+            socket.write_all(&[5, 0]).await.unwrap();
+
+            let mut request = [0; 4];
+            socket.read_exact(&mut request).await.unwrap();
+            assert_eq!(request[..3], [5, 1, 0]);
+            assert_eq!(request[3], 3);
+
+            let mut domain_len = [0; 1];
+            socket.read_exact(&mut domain_len).await.unwrap();
+            let mut domain = vec![0; domain_len[0] as usize];
+            socket.read_exact(&mut domain).await.unwrap();
+            let mut port = [0; 2];
+            socket.read_exact(&mut port).await.unwrap();
+            let target = (String::from_utf8(domain).unwrap(), u16::from_be_bytes(port));
+            target_sender.send(target).unwrap();
+
+            socket
+                .write_all(&[5, 0, 0, 1, 0, 0, 0, 0, 0, 0])
+                .await
+                .unwrap();
+        });
+
+        let address: Multiaddr = "/dns4/tentacle-proxy-leak.invalid/tcp/4242"
+            .parse()
+            .unwrap();
+        let tcp_config = TcpSocketConfig {
+            proxy_url: Some(format!("socks5://{}", proxy_addr).parse().unwrap()),
+            proxy_random_auth: false,
+            ..Default::default()
+        };
+        let transport = TcpTransport::new(Duration::from_secs(5), tcp_config);
+
+        let (dialed_addr, _stream) = transport.dial(address.clone()).unwrap().await.unwrap();
+        assert_eq!(dialed_addr, address);
+        assert_eq!(
+            target_receiver.await.unwrap(),
+            ("tentacle-proxy-leak.invalid".to_string(), 4242)
+        );
     }
 }

--- a/tentacle/src/utils/dns.rs
+++ b/tentacle/src/utils/dns.rs
@@ -69,6 +69,10 @@ impl DnsResolver {
         }
     }
 
+    pub(crate) fn tcp_target(&self) -> (&str, u16) {
+        (&self.domain, self.port)
+    }
+
     fn new_addr(
         &mut self,
         mut iter: IntoIter<SocketAddr>,


### PR DESCRIPTION
## Summary

- skip local DNS resolution for proxied TCP dials to `/dns4` and `/dns6` multiaddrs
- pass the original hostname and port to the SOCKS proxy for proxy-side resolution
- add a regression test with a fake SOCKS5 server that verifies ATYP=domain is used

## Rationale

When `tcp_proxy_config` is enabled, DNS destinations should be resolved by the configured SOCKS proxy. Resolving `/dns4` or `/dns6` locally before proxy dialing leaks the target hostname outside the proxy/Tor path.

## Tests

- `cargo fmt --check`
- `cargo test -p tentacle proxy_dns_dial_sends_hostname_to_socks_server -- --nocapture`