### PR TITLE
Validate P2P bytes before serializing multiaddrs

### DIFF
--- a/multiaddr/src/protocol.rs
+++ b/multiaddr/src/protocol.rs
@@ -237,6 +237,7 @@ impl<'a> Protocol<'a> {
                 w.put(bytes)
             }
             Protocol::P2P(b) => {
+                check_p2p(b).expect("invalid p2p multihash bytes");
                 w.put(encode::u32(P2P, &mut buf));
                 w.put(encode::usize(b.len(), &mut encode::usize_buffer()));
                 w.put(&b[..])

--- a/multiaddr/tests/lib.rs
+++ b/multiaddr/tests/lib.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use parity_multiaddr::{Multiaddr as OtherMultiaddr, Protocol as OtherProtocol};
 use tentacle_multiaddr::{Multiaddr, Protocol};
 mod onion;
@@ -40,4 +42,46 @@ fn empty_test() {
 
     let address = "".parse::<Multiaddr>().unwrap_err();
     assert_eq!(address.to_string(), "invalid multiaddr");
+}
+
+fn invalid_p2p() -> Protocol<'static> {
+    Protocol::P2P(Cow::Owned(vec![0]))
+}
+
+#[test]
+#[should_panic(expected = "invalid p2p multihash bytes")]
+fn invalid_p2p_protocol_rejected_by_from_protocol() {
+    let _address = Multiaddr::from(invalid_p2p());
+}
+
+#[test]
+#[should_panic(expected = "invalid p2p multihash bytes")]
+fn invalid_p2p_protocol_rejected_by_push() {
+    let mut address: Multiaddr = "/ip4/127.0.0.1/tcp/10000".parse().unwrap();
+    address.push(invalid_p2p());
+}
+
+#[test]
+#[should_panic(expected = "invalid p2p multihash bytes")]
+fn invalid_p2p_protocol_rejected_by_from_iterator() {
+    let _address: Multiaddr = vec![invalid_p2p()].into_iter().collect();
+}
+
+#[test]
+fn valid_p2p_protocol_constructors_still_work() {
+    let source = "/p2p/QmNQ4jky6uVqLDrPU7snqxARuNGWNLgSrTnssbRuy3ij2W";
+    let mut parsed: Multiaddr = source.parse().unwrap();
+    let p2p = parsed.pop().unwrap();
+
+    assert_eq!(Multiaddr::from(p2p.clone()).to_string(), source);
+
+    let mut pushed: Multiaddr = "/ip4/127.0.0.1/tcp/10000".parse().unwrap();
+    pushed.push(p2p.clone());
+    assert_eq!(
+        pushed.to_string(),
+        format!("/ip4/127.0.0.1/tcp/10000{}", source)
+    );
+
+    let collected: Multiaddr = vec![p2p].into_iter().collect();
+    assert_eq!(collected.to_string(), source);
 }


### PR DESCRIPTION
## Summary

- validate `Protocol::P2P` bytes before writing them into a `Multiaddr`
- prevent safe construction APIs from creating internally invalid multiaddrs
- add regression tests for `Multiaddr::from`, `push`, and `FromIterator`

## Rationale

`Protocol::P2P` is publicly constructible from raw bytes. Parsers already validate P2P bytes, but construction paths serialized them directly, allowing invalid internal `Multiaddr` values that could later panic during iteration or display.

This keeps the existing API shape while enforcing the same P2P invariant at serialization time.

## Tests

- `cargo fmt --check`
- `cargo test -p tentacle-multiaddr -- --nocapture`