### PR TITLE
Fix max connection limit off-by-one check

### DIFF
--- a/tentacle/src/service.rs
+++ b/tentacle/src/service.rs
@@ -69,6 +69,17 @@ pub use crate::service::config::TlsConfig;
 
 type Result<T> = std::result::Result<T, TransportErrorKind>;
 
+fn has_reached_max_connection_limit(
+    max_connection_number: usize,
+    active_sessions: usize,
+    pending_sessions: usize,
+) -> bool {
+    active_sessions
+        .checked_add(pending_sessions)
+        .map(|count| count >= max_connection_number)
+        .unwrap_or(true)
+}
+
 /// Output of the transport-agnostic session-registration steps. The caller
 /// uses these fields to build a per-multiplexer session loop (`Session` for
 /// yamux, `QuicSession` for QUIC).
@@ -424,6 +435,23 @@ where
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::has_reached_max_connection_limit;
+
+    #[test]
+    fn connection_limit_treats_equal_count_as_reached() {
+        assert!(!has_reached_max_connection_limit(2, 1, 0));
+        assert!(has_reached_max_connection_limit(2, 2, 0));
+        assert!(has_reached_max_connection_limit(2, 1, 1));
+    }
+
+    #[test]
+    fn connection_limit_fails_closed_on_count_overflow() {
+        assert!(has_reached_max_connection_limit(usize::MAX, usize::MAX, 1));
     }
 }
 
@@ -930,11 +958,11 @@ where
     }
 
     fn reached_max_connection_limit(&self) -> bool {
-        self.sessions
-            .len()
-            .checked_add(self.state.into_inner().unwrap_or_default())
-            .map(|count| self.config.max_connection_number < count)
-            .unwrap_or_default()
+        has_reached_max_connection_limit(
+            self.config.max_connection_number,
+            self.sessions.len(),
+            self.state.into_inner().unwrap_or_default(),
+        )
     }
 
     /// Common session-registration steps shared by yamux and QUIC paths

--- a/tentacle/src/service.rs
+++ b/tentacle/src/service.rs
@@ -69,17 +69,6 @@ pub use crate::service::config::TlsConfig;
 
 type Result<T> = std::result::Result<T, TransportErrorKind>;
 
-fn has_reached_max_connection_limit(
-    max_connection_number: usize,
-    active_sessions: usize,
-    pending_sessions: usize,
-) -> bool {
-    active_sessions
-        .checked_add(pending_sessions)
-        .map(|count| count >= max_connection_number)
-        .unwrap_or(true)
-}
-
 /// Output of the transport-agnostic session-registration steps. The caller
 /// uses these fields to build a per-multiplexer session loop (`Session` for
 /// yamux, `QuicSession` for QUIC).
@@ -435,23 +424,6 @@ where
                 }
             }
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::has_reached_max_connection_limit;
-
-    #[test]
-    fn connection_limit_treats_equal_count_as_reached() {
-        assert!(!has_reached_max_connection_limit(2, 1, 0));
-        assert!(has_reached_max_connection_limit(2, 2, 0));
-        assert!(has_reached_max_connection_limit(2, 1, 1));
-    }
-
-    #[test]
-    fn connection_limit_fails_closed_on_count_overflow() {
-        assert!(has_reached_max_connection_limit(usize::MAX, usize::MAX, 1));
     }
 }
 
@@ -958,11 +930,11 @@ where
     }
 
     fn reached_max_connection_limit(&self) -> bool {
-        has_reached_max_connection_limit(
-            self.config.max_connection_number,
-            self.sessions.len(),
-            self.state.into_inner().unwrap_or_default(),
-        )
+        self.sessions
+            .len()
+            .checked_add(self.state.into_inner().unwrap_or_default())
+            .map(|count| self.config.max_connection_number <= count)
+            .unwrap_or(true)
     }
 
     /// Common session-registration steps shared by yamux and QUIC paths


### PR DESCRIPTION
### Summary

This fixes an off-by-one error in the service connection limit check.

Previously, `reached_max_connection_limit()` only returned true when the current active plus pending session count was greater than `max_connection_number`. Because the check runs before inserting the new session, a service that had already reached the configured limit could still accept one extra connection.

### Changes

- Treat `count == max_connection_number` as already at capacity.
- Fail closed if active plus pending session counting overflows.
- Add regression tests for the equality boundary and overflow behavior.

### Tests

- `cargo fmt --check`
- `cargo test -p tentacle connection_limit -- --nocapture`
- `git diff --check`