### PR TITLE
Fix forged yamux ping ACKs bypassing keepalive timeouts

### DIFF
--- a/multiaddr/Cargo.toml
+++ b/multiaddr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tentacle-multiaddr"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["driftluo <driftluo@foxmail.com>"]
 edition = "2024"
 rust-version = "1.85.0"

--- a/secio/Cargo.toml
+++ b/secio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tentacle-secio"
-version = "0.6.7"
+version = "0.6.8"
 license = "MIT"
 description = "Secio encryption protocol for p2p"
 authors = ["piaoliu <driftluo@foxmail.com>", "Nervos Core Dev <dev@nervos.org>"]

--- a/tentacle/Cargo.toml
+++ b/tentacle/Cargo.toml
@@ -18,8 +18,8 @@ no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-yamux = { path = "../yamux", version = "0.3.14", default-features = false, package = "tokio-yamux" }
-secio = { path = "../secio", version = "0.6.6", package = "tentacle-secio" }
+yamux = { path = "../yamux", version = "0.3.19", default-features = false, package = "tokio-yamux" }
+secio = { path = "../secio", version = "0.6.8", package = "tentacle-secio" }
 
 futures = { version = "0.3.0" }
 tokio = { version = "1.0.0", features = ["macros"] }
@@ -35,7 +35,7 @@ tokio-tungstenite = { version = "0.28", optional = true }
 httparse = { version = "1.9", optional = true }
 futures-timer = { version = "3.0.2", optional = true }
 
-multiaddr = { path = "../multiaddr", package = "tentacle-multiaddr", version = "0.3.6" }
+multiaddr = { path = "../multiaddr", package = "tentacle-multiaddr", version = "0.3.7" }
 url = "2.5.4"
 molecule = "0.9.0"
 

--- a/tentacle/Cargo.toml
+++ b/tentacle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tentacle"
-version = "0.7.5"
+version = "0.7.6"
 license = "MIT"
 description = "Minimal implementation for a multiplexed p2p network framework."
 authors = ["piaoliu <driftluo@foxmail.com>", "Nervos Core Dev <dev@nervos.org>"]

--- a/yamux/Cargo.toml
+++ b/yamux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-yamux"
-version = "0.3.18"
+version = "0.3.19"
 license = "MIT"
 repository = "https://github.com/nervosnetwork/tentacle"
 description = "Rust implementation of Yamux"

--- a/yamux/src/session.rs
+++ b/yamux/src/session.rs
@@ -530,9 +530,6 @@ where
             }
             #[cfg(not(feature = "metrics"))]
             let _ = sent_ping_at;
-            // If the remote peer does not follow the protocol,
-            // there may be a memory leak, so here need to discard all ping ids below the ack.
-            self.pings = self.pings.split_off(&ping_id);
         } else {
             // TODO: unexpected case, send a GoAwayCode::ProtocolError ?
         }
@@ -937,7 +934,7 @@ pub(crate) fn rt() -> &'static tokio::runtime::Runtime {
 
 #[cfg(test)]
 mod test {
-    use super::{Session, rt};
+    use super::{Session, TIMEOUT, rt};
     use crate::{
         config::Config,
         frame::{Flag, Flags, Frame, FrameCodec, GoAwayCode, Type},
@@ -952,7 +949,7 @@ mod test {
         io,
         pin::Pin,
         task::{Context, Poll},
-        time::Duration,
+        time::{Duration, Instant},
     };
     use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
     use tokio_util::codec::Framed;
@@ -1092,6 +1089,50 @@ mod test {
                 }
             }
         })
+    }
+
+    #[test]
+    fn test_ping_ack_only_removes_matching_ping() {
+        let (remote, local) = MockSocket::new();
+        let config = Config {
+            enable_keepalive: false,
+            ..Default::default()
+        };
+        let mut session = Session::new_server(local, config);
+        let now = Instant::now();
+        session.pings.insert(1, now);
+        session.pings.insert(2, now);
+
+        let mut cx = Context::from_waker(noop_waker_ref());
+        session
+            .handle_ping(&mut cx, &Frame::new_ping(Flags::from(Flag::Ack), 2))
+            .unwrap();
+
+        assert!(session.pings.contains_key(&1));
+        assert!(!session.pings.contains_key(&2));
+        drop(remote);
+    }
+
+    #[test]
+    fn test_forged_ping_ack_does_not_clear_pending_pings() {
+        let (remote, local) = MockSocket::new();
+        let config = Config {
+            enable_keepalive: false,
+            ..Default::default()
+        };
+        let mut session = Session::new_server(local, config);
+        let now = Instant::now();
+        session
+            .pings
+            .insert(1, now - TIMEOUT - Duration::from_secs(1));
+
+        let mut cx = Context::from_waker(noop_waker_ref());
+        session
+            .handle_ping(&mut cx, &Frame::new_ping(Flags::from(Flag::Ack), u32::MAX))
+            .unwrap();
+
+        assert!(session.keep_alive(&mut cx, now).is_err());
+        drop(remote);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Only remove the ping entry matching an incoming ACK.
- Prevent forged ACK IDs from clearing pending keepalive pings.
- Add regression tests for forged and non-cumulative ACK handling.

## Testing

- cargo test -p tokio-yamux