### PR TITLE
Validate peer-supplied discovery listen port before storing

### DIFF
--- a/protocols/discovery/src/lib.rs
+++ b/protocols/discovery/src/lib.rs
@@ -14,7 +14,7 @@ use rand::seq::SliceRandom;
 
 pub use addr::{AddressManager, MisbehaveResult, Misbehavior};
 use protocol::{decode, encode, DiscoveryMessage, Node, Nodes};
-use state::{RemoteAddress, SessionState};
+use state::SessionState;
 
 mod addr;
 mod protocol;
@@ -122,11 +122,21 @@ impl<M: AddressManager> ServiceProtocol for DiscoveryProtocol<M> {
                             // change client random outbound port to client listen port
                             debug!("listen port: {:?}", listen_port);
                             if let Some(port) = listen_port {
-                                state.remote_addr.update_port(port);
-                                state.addr_known.insert(state.remote_addr.to_inner());
-                                // add client listen address to manager
-                                if let RemoteAddress::Listen(ref addr) = state.remote_addr {
-                                    self.addr_mgr.add_new_addr(session.id, addr.clone());
+                                // `listen_port` is peer-controlled and
+                                // unauthenticated. `apply_listen_port` rejects
+                                // obviously invalid values (e.g. port 0); the
+                                // rewritten `Listen` address is then validated by
+                                // the address manager, the same gate the announce
+                                // path already applies, before it is stored. This
+                                // prevents a malicious peer from poisoning the
+                                // store with an invalid endpoint for its observed
+                                // source IP.
+                                if let Some(addr) = state.apply_listen_port(port) {
+                                    if self.addr_mgr.is_valid_addr(&addr) {
+                                        state.mark_listen_addr_known(&addr);
+                                        // add client listen address to manager
+                                        self.addr_mgr.add_new_addr(session.id, addr);
+                                    }
                                 }
                             }
 

--- a/protocols/discovery/src/state.rs
+++ b/protocols/discovery/src/state.rs
@@ -67,6 +67,33 @@ impl SessionState {
         }
     }
 
+    /// Apply a peer-supplied `listen_port` to the remote address and return the
+    /// rewritten `Listen` address candidate.
+    ///
+    /// The port is peer-controlled and unauthenticated, so `update_port` rejects
+    /// obviously invalid values (e.g. port 0) and only promotes `Init` addresses
+    /// to `Listen`. The returned candidate must still be validated by the
+    /// address manager (see `mark_listen_addr_known`) before it is stored or
+    /// announced, so a malicious peer cannot poison the store with an invalid
+    /// endpoint for its observed source IP.
+    ///
+    /// Returns the rewritten `Listen` address, or `None` if the port was
+    /// rejected or the address was not an `Init` address.
+    pub(crate) fn apply_listen_port(&mut self, port: u16) -> Option<Multiaddr> {
+        if !self.remote_addr.update_port(port) {
+            return None;
+        }
+        match &self.remote_addr {
+            RemoteAddress::Listen(addr) => Some(addr.clone()),
+            RemoteAddress::Init(_) => None,
+        }
+    }
+
+    /// Record a validated listen address in the per-session known-address set.
+    pub(crate) fn mark_listen_addr_known(&mut self, addr: &Multiaddr) {
+        self.addr_known.insert(addr);
+    }
+
     pub(crate) fn check_timer(&mut self, now: Instant, interval: Duration) -> Option<&Multiaddr> {
         if self
             .last_announce
@@ -120,7 +147,20 @@ impl RemoteAddress {
         }
     }
 
-    pub(crate) fn update_port(&mut self, port: u16) {
+    /// Rewrite the transport port with the peer-supplied listen port and mark
+    /// the address as a `Listen` address.
+    ///
+    /// The `port` is peer-controlled and unauthenticated, so obviously invalid
+    /// values are rejected here as a first line of defense before the address
+    /// is stored or announced. Port `0` is never a valid listen endpoint (it
+    /// means "any port" when binding and is not dialable), so it is dropped and
+    /// the address is left untouched.
+    ///
+    /// Returns `true` when the address was rewritten to a `Listen` address.
+    pub(crate) fn update_port(&mut self, port: u16) -> bool {
+        if port == 0 {
+            return false;
+        }
         if let RemoteAddress::Init(ref addr) = self {
             let addr = addr
                 .into_iter()
@@ -133,6 +173,107 @@ impl RemoteAddress {
                 })
                 .collect();
             *self = RemoteAddress::Listen(addr);
+            true
+        } else {
+            false
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RemoteAddress, SessionState};
+    use crate::addr::AddrKnown;
+    use p2p::multiaddr::Multiaddr;
+
+    fn addr(s: &str) -> Multiaddr {
+        s.parse().unwrap()
+    }
+
+    fn state_with(remote_addr: RemoteAddress) -> SessionState {
+        SessionState {
+            addr_known: AddrKnown::default(),
+            remote_addr,
+            last_announce: None,
+            announce_multiaddrs: Vec::new(),
+            received_get_nodes: false,
+            received_nodes: false,
+        }
+    }
+
+    // A peer-supplied listen port of 0 is not a valid dialable endpoint and
+    // must be rejected: the address must stay `Init` and no rewrite happens.
+    #[test]
+    fn update_port_rejects_zero_port() {
+        let mut remote = RemoteAddress::Init(addr("/ip4/198.51.100.66/tcp/49152"));
+        assert!(!remote.update_port(0));
+        assert_eq!(
+            remote,
+            RemoteAddress::Init(addr("/ip4/198.51.100.66/tcp/49152"))
+        );
+    }
+
+    // A valid peer-supplied listen port rewrites the observed outbound port and
+    // promotes the address to `Listen`, keeping the observed IP unchanged.
+    #[test]
+    fn update_port_rewrites_valid_port_and_marks_listen() {
+        let mut remote = RemoteAddress::Init(addr("/ip4/198.51.100.66/tcp/49152"));
+        assert!(remote.update_port(9));
+        assert_eq!(
+            remote,
+            RemoteAddress::Listen(addr("/ip4/198.51.100.66/tcp/9"))
+        );
+    }
+
+    // `update_port` only promotes `Init` addresses. An address that is already
+    // `Listen` must not be rewritten again by a later peer-supplied port.
+    #[test]
+    fn update_port_does_not_rewrite_listen() {
+        let mut remote = RemoteAddress::Listen(addr("/ip4/198.51.100.66/tcp/1337"));
+        assert!(!remote.update_port(4444));
+        assert_eq!(
+            remote,
+            RemoteAddress::Listen(addr("/ip4/198.51.100.66/tcp/1337"))
+        );
+    }
+
+    // A rejected port (0) yields no candidate address to store, so the store
+    // poisoning path is closed at the source.
+    #[test]
+    fn apply_listen_port_rejects_zero_port() {
+        let mut state = state_with(RemoteAddress::Init(addr("/ip4/198.51.100.66/tcp/49152")));
+        assert_eq!(state.apply_listen_port(0), None);
+        // Address must remain the un-promoted Init address.
+        assert_eq!(
+            state.remote_addr,
+            RemoteAddress::Init(addr("/ip4/198.51.100.66/tcp/49152"))
+        );
+    }
+
+    // A valid port produces a Listen candidate that keeps the observed IP and
+    // only differs in the peer-claimed port.
+    #[test]
+    fn apply_listen_port_returns_listen_candidate() {
+        let mut state = state_with(RemoteAddress::Init(addr("/ip4/198.51.100.66/tcp/49152")));
+        assert_eq!(
+            state.apply_listen_port(9),
+            Some(addr("/ip4/198.51.100.66/tcp/9"))
+        );
+        assert_eq!(
+            state.remote_addr,
+            RemoteAddress::Listen(addr("/ip4/198.51.100.66/tcp/9"))
+        );
+    }
+
+    // Once an address is Listen, a later peer-supplied port cannot rewrite it,
+    // so no new candidate is produced.
+    #[test]
+    fn apply_listen_port_no_candidate_when_already_listen() {
+        let mut state = state_with(RemoteAddress::Listen(addr("/ip4/198.51.100.66/tcp/1337")));
+        assert_eq!(state.apply_listen_port(4444), None);
+        assert_eq!(
+            state.remote_addr,
+            RemoteAddress::Listen(addr("/ip4/198.51.100.66/tcp/1337"))
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Reject an obviously invalid peer-supplied `listen_port` (port 0) before rewriting the remote address.
- Validate the rewritten `Listen` address through the address manager before storing it, the same gate the announce path already applies.
- Add unit tests for the listen-port rewrite and validation logic.

## Motivation

On the first inbound `GetNodes`, the discovery protocol rewrites the observed remote address to the peer-supplied `listen_port`, promotes it to a `RemoteAddress::Listen`, records it in `addr_known`, and adds it to the address manager. This port is peer-controlled and unauthenticated.

Previously the rewrite was unconditional: port 0 was accepted, and the resulting address was stored via `add_new_addr` without passing through `is_valid_addr`. The announce path already filters listen addresses with `is_valid_addr`, but the store path did not, so a peer could seed its observed source IP with an invalid or non-dialable port. The impact is bounded to the peer's own observed IP (the IP is never rewritten, only the port), but the missing validation lets that endpoint enter the peer store and downstream dial scheduling.

This change rejects port 0 at the source and requires the rewritten `Listen` address to pass the address manager's `is_valid_addr` gate before it is recorded or stored, so applications can enforce reachability/ownership policy consistently on both the store and announce paths.

## Tests

- `cargo fmt --check`
- `cargo test --manifest-path protocols/discovery/Cargo.toml state::tests`

Note: `cargo test` for `protocols/discovery` could not be executed in this environment because the crate depends on `tentacle = ^0.3.0` while the local path package is `0.7.5` (a pre-existing constraint, unrelated to this change). The rewrite/validation logic was verified with a standalone program built against `tentacle-multiaddr`, covering port-0 rejection, `Init`->`Listen` promotion with the IP preserved, no re-rewrite of an existing `Listen`, and the `is_valid_addr` gate blocking storage when validation fails.