### PR TITLE
fix: clear session notify timers on protocol close

### DIFF
--- a/tentacle/src/protocol_handle_stream.rs
+++ b/tentacle/src/protocol_handle_stream.rs
@@ -387,6 +387,7 @@ where
                     .await
             }
             Closed => {
+                self.notify.clear();
                 self.handle
                     .disconnected(self.handle_context.as_mut(&self.context))
                     .await


### PR DESCRIPTION
## Summary

Fixes a resource leak where session notify timers continue firing after a protocol is closed on a still-open session.

## Problem

When a protocol closes (`SessionProtocolEvent::Closed`), `SessionProtocolStream` calls the user handler `disconnected()` but does **not** clear `self.notify`. Any notify timers set via `set_session_notify` during the protocol open lifecycle keep cycling indefinitely:

1. `set_notify()` spawns a delayed task that re-schedules itself
2. After `Closed`, stale timers continue to fire `handle.notify()` on a now-closed protocol
3. Repeated protocol open/close cycles accumulate more stale timer cycles

## Fix

One line change — clear `self.notify` when `Closed` is received:

```rust
Closed => {
    self.notify.clear();  // ← added
    self.handle
        .disconnected(self.handle_context.as_mut(&self.context))
        .await
}
```

Any in-flight notification (already in the channel) fires one last time but is not re-scheduled because `set_notify()` checks `self.notify.get(&token)` which returns `None` after the clear.